### PR TITLE
Add revision-guard: anti over-refinement skill for academic writing

### DIFF
--- a/docs/07-论文修改与润色.md
+++ b/docs/07-论文修改与润色.md
@@ -86,6 +86,36 @@ quality-reviewer（质量审阅器）
 | **检查项** | 贡献清晰度、识别策略可信度、因果过度声称、未支持的声明 |
 | **支持** | Top-5 经济学期刊 + 顶级金融期刊 |
 
+### revision-guard（防过度修改与同质化）
+
+| 属性 | 说明 |
+|------|------|
+| **来源** | [ShiyanW/ai-revision-guard](https://github.com/ShiyanW/ai-revision-guard) |
+| **功能** | 防止 AI 越改越差——限制修改轮次、检测同质化、保护作者 voice |
+| **安装** | `git clone https://github.com/ShiyanW/ai-revision-guard.git ~/.claude/skills/revision-guard` |
+
+**解决的问题**：
+
+AI 总能找到"改进空间"，用户反复迭代后反而得到更差的结果——Liz Fosslien 称之为"Frankenstein-ed slop"。研究表明 LLM 修改量是人类的 3 倍，论点向中性偏移 70%（CHI 2025; Georgetown 2025）。
+
+**工作流**：
+
+```
+Step 0: 锚定 — 锁定用户满意的内容（不是初稿，是用户确认的版本）
+Step 1: 分类 — 结构/实质/语言/格式/全面重写，各有明确边界
+Step 2: 执行 — 最小有效改动，15 个禁止的 AI 替换模式
+Step 3: 报告 — 自评：实质改进 / 微调 / 边际（边际则建议停止）
+Step 4: 限制 — 每节最多 2 轮，第 3 轮触发警告
+Step 5: 检测 — 7 项同质化清单，2+ 项触发则警告并提供回滚
+Step 5b: 交叉验证（可选）— 发送修改前后文本给 Codex/GPT 独立判断
+```
+
+**特色**：
+- 8 个领域预设（经济学、法学、医学、人文、STEM、心理学、政治学、教育学）自动锁定核心学术判断
+- 锁定保护 voice 但不保护事实错误——发现锁定区有错会主动标记
+- 附带 `scripts/diff-check.py` 自动检测同质化信号（词数膨胀、第一人称消失、hedge 词增加等）
+- 研究支撑：8 项学术来源（CHI 2025、Georgetown 2025、Xie & Xie 2026 等）
+
 ---
 
 ## 从 Skill 到 Custom Agent 系统


### PR DESCRIPTION
## What this adds

[revision-guard](https://github.com/ShiyanW/ai-revision-guard) — an agent skill that prevents AI over-refinement and homogenization in academic writing.

## Why it belongs here

This skill addresses a documented problem in AI-assisted academic writing: LLMs make 3x the lexical changes humans do (CHI 2025), shift arguments 70% toward neutrality, and erase the author's voice through iterative revision. No existing skill in this collection specifically prevents over-editing.

## Category

Added to `docs/07-论文修改与润色.md` — fits naturally alongside copy-edit-master and AI-research-feedback.

## Features

- 6-step protocol: anchor → classify → execute → report → limit → detect
- 8 domain presets (economics, law, medicine, humanities, STEM, psychology, political science, education)
- 7-point homogenization detection checklist
- Optional cross-model verification via Codex
- Backed by 8 research sources