### PR TITLE
Improve/skill review optimization

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main

--- a/skills/00-brycewang-stanford-StatsPAI/SKILL.md
+++ b/skills/00-brycewang-stanford-StatsPAI/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statspai
-description: Agent-native causal inference & econometrics toolkit for Python. 390+ functions, one import, unified API. Covers OLS, IV, DID, staggered DID, RDD, PSM, SCM, DML, Causal Forest, Meta-Learners, TMLE, neural causal models, and more. Every function returns structured result objects with self-describing schemas for LLM-driven workflows.
+description: "Agent-native causal inference and econometrics toolkit for Python. 390+ functions, one import, unified API. Covers OLS, IV, DID, staggered DID, RDD, PSM, SCM, DML, Causal Forest, Meta-Learners, TMLE, neural causal models, and more. Use when the user asks about treatment effect estimation, causal analysis, regression analysis, policy evaluation, observational study methods, or any of the listed econometric methods in Python. Every function returns structured result objects with self-describing schemas for LLM-driven workflows."
 triggers:
   - implement causal inference
   - run a DID analysis
@@ -12,6 +12,10 @@ triggers:
   - causal forest
   - panel data regression
   - econometric analysis
+  - treatment effect estimation
+  - causal analysis
+  - policy evaluation
+  - observational study
   - StatsPAI
   - statspai
 ---
@@ -24,13 +28,13 @@ StatsPAI is the agent-native Python package for causal inference and applied eco
 **PyPI**: `pip install statspai`
 **Paper**: Published in Journal of Open Source Software (JOSS)
 
-## Why StatsPAI for Agents?
+## Agent API
 
-StatsPAI is the **first econometrics toolkit purpose-built for LLM-driven research workflows**:
+StatsPAI provides a self-describing API for agent-driven workflows:
 
-1. **Self-describing API**: `sp.list_functions()`, `sp.describe_function("did")`, `sp.function_schema("rdrobust")` — agents can discover and understand functions without documentation lookup
-2. **Unified result objects**: Every function returns a `CausalResult` with `.summary()`, `.plot()`, `.to_latex()`, `.to_word()`, `.to_excel()`, `.cite()`
-3. **One import**: No need to juggle 20+ packages — `import statspai as sp` covers everything
+1. **Discovery**: `sp.list_functions()`, `sp.describe_function("did")`, `sp.function_schema("rdrobust")` — discover and understand functions without external documentation
+2. **Unified results**: Every function returns a `CausalResult` with `.summary()`, `.plot()`, `.to_latex()`, `.to_word()`, `.to_excel()`, `.cite()`
+3. **One import**: `import statspai as sp` covers all 390+ functions
 4. **Publication-ready output**: Word, Excel, LaTeX, HTML export in every function
 
 ## Core Methods
@@ -128,13 +132,24 @@ print(result.summary())
 result.to_latex("tables/did_results.tex")
 ```
 
-## When to Use StatsPAI vs Other Packages
+## Validation and Error Handling
 
-| Scenario | Use StatsPAI | Alternative |
-|----------|-------------|-------------|
-| Agent-driven analysis pipeline | ✅ Best choice — self-describing API | pyfixest (no agent API) |
-| Full causal inference workflow | ✅ 390+ functions, one import | Assemble 10+ R/Python packages |
-| Publication-ready output needed | ✅ Word/Excel/LaTeX/HTML built-in | statsmodels (no export) |
-| Staggered DID with diagnostics | ✅ CS + SA + Bacon + HonestDID | differences (partial) |
-| Neural causal models | ✅ TARNet/CFRNet/DragonNet | econml (partial) |
-| Stata users migrating to Python | ✅ Stata-equivalent function names | linearmodels (limited) |
+After running any estimation, check the result before proceeding:
+
+```python
+result = sp.did(df, "y", "treated", "post")
+
+# Check convergence and diagnostics
+print(result.summary())
+
+# Verify key assumptions
+if hasattr(result, 'diagnostics'):
+    print(result.diagnostics)
+```
+
+Common issues to check:
+- **Convergence warnings** in `.summary()` output
+- **Weak instruments** for IV: check first-stage F-statistic > 10
+- **Parallel trends** for DID: run event study and inspect pre-treatment coefficients
+- **Bandwidth sensitivity** for RDD: compare results at half and double the optimal bandwidth
+- **Missing data**: StatsPAI drops missing values by default — verify sample sizes match expectations

--- a/skills/03-K-Dense-AI-claude-scientific-skills/literature-review/SKILL.md
+++ b/skills/03-K-Dense-AI-claude-scientific-skills/literature-review/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: literature-review
+description: "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). Use when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.)."
+allowed-tools: Read Write Edit Bash
+license: MIT license
+metadata:
+    skill-author: K-Dense Inc.
+---
+
 <!--
   ╔══════════════════════════════════════════════════════════════╗
   ║  本文件为开源 Skill 原始文档，收录仅供学习与研究参考        ║
@@ -12,15 +21,6 @@
   声明: 本文件版权归原作者所有。此处收录旨在为社会科学实证研究者
   提供 AI Agent Skills 的集中参考。如有侵权，请联系删除。
 -->
-
----
-name: literature-review
-description: Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).
-allowed-tools: Read Write Edit Bash
-license: MIT license
-metadata:
-    skill-author: K-Dense Inc.
----
 
 # Literature Review
 
@@ -461,12 +461,6 @@ For any topic, identify foundational work by:
 3. **Document everything**: Search strings, dates, result counts for reproducibility
 4. **Test and refine**: Run pilot searches, review results, adjust search terms
 5. **Sort by citations**: When available, sort search results by citation count to surface influential work first
-
-### Screening and Selection
-1. **Use multiple databases** (minimum 3): Ensures comprehensive coverage
-2. **Include preprint servers**: Captures latest unpublished findings
-3. **Document everything**: Search strings, dates, result counts for reproducibility
-4. **Test and refine**: Run pilot searches, review results, adjust search terms
 
 ### Screening and Selection
 1. **Use clear criteria**: Document inclusion/exclusion criteria before screening

--- a/skills/07-Orchestra-Research-AI-Research-SKILLs/ml-paper-writing/SKILL.md
+++ b/skills/07-Orchestra-Research-AI-Research-SKILLs/ml-paper-writing/SKILL.md
@@ -1,3 +1,13 @@
+---
+name: ml-paper-writing
+description: "Write publication-ready ML/AI/Systems papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM, OSDI, NSDI, ASPLOS, SOSP. Use when drafting papers from research repos, structuring arguments, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, reviewer guidelines, and citation verification workflows."
+version: 1.1.0
+author: Orchestra Research
+license: MIT
+tags: [Academic Writing, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, OSDI, NSDI, ASPLOS, SOSP, LaTeX, Paper Writing, Citations, Research, Systems]
+dependencies: [semanticscholar, arxiv, habanero, requests]
+---
+
 <!--
   ╔══════════════════════════════════════════════════════════════╗
   ║  本文件为开源 Skill 原始文档，收录仅供学习与研究参考        ║
@@ -12,16 +22,6 @@
   声明: 本文件版权归原作者所有。此处收录旨在为社会科学实证研究者
   提供 AI Agent Skills 的集中参考。如有侵权，请联系删除。
 -->
-
----
-name: ml-paper-writing
-description: Write publication-ready ML/AI/Systems papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM, OSDI, NSDI, ASPLOS, SOSP. Use when drafting papers from research repos, structuring arguments, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, reviewer guidelines, and citation verification workflows.
-version: 1.1.0
-author: Orchestra Research
-license: MIT
-tags: [Academic Writing, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, OSDI, NSDI, ASPLOS, SOSP, LaTeX, Paper Writing, Citations, Research, Systems]
-dependencies: [semanticscholar, arxiv, habanero, requests]
----
 
 # ML Paper Writing for Top AI & Systems Conferences
 

--- a/skills/08-ndpvt-web-latex-document-skill/SKILL.md
+++ b/skills/08-ndpvt-web-latex-document-skill/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: latex-document
+description: "Universal LaTeX document skill for creating, compiling, and converting documents to professional PDF with PNG previews. Use when the user asks to write a LaTeX document, create a resume/CV, compile a .tex file, make a report/presentation/thesis, create charts/diagrams, convert between document formats (Markdown/DOCX/HTML to/from LaTeX), convert/OCR a PDF to LaTeX, create fillable PDF forms, or perform any PDF operation (merge, encrypt, extract, watermark). Supports pdflatex, xelatex, and lualatex with auto-detection, bibliography management, multi-language/CJK, and batch processing pipelines."
+---
+
 <!--
   ╔══════════════════════════════════════════════════════════════╗
   ║  本文件为开源 Skill 原始文档，收录仅供学习与研究参考        ║
@@ -12,68 +17,6 @@
   声明: 本文件版权归原作者所有。此处收录旨在为社会科学实证研究者
   提供 AI Agent Skills 的集中参考。如有侵权，请联系删除。
 -->
-
----
-name: latex-document
-description: >
-  Universal LaTeX document skill: create, compile, and convert any document to
-  professional PDF with PNG previews. Supports resumes, reports, cover letters,
-  invoices, academic papers, theses/dissertations, academic CVs, presentations
-  (Beamer), scientific posters, formal letters, exams/quizzes, books,
-  cheat sheets, reference cards, exam formula sheets,
-  fillable PDF forms (hyperref form fields), conditional content (etoolbox toggles),
-  mail merge from CSV/JSON (Jinja2 templates), version diffing (latexdiff),
-  charts (pgfplots + matplotlib), tables (booktabs + CSV import), images (TikZ),
-  Mermaid diagrams, AI-generated images, watermarks, landscape pages,
-  bibliography/citations (BibTeX/biblatex), multi-language/CJK (auto XeLaTeX),
-  algorithms/pseudocode, colored boxes (tcolorbox), SI units (siunitx),
-  Pandoc format conversion (Markdown/DOCX/HTML ↔ LaTeX),
-  and PDF-to-LaTeX conversion of handwritten or printed documents (math, business,
-  legal, general). Compile script supports pdflatex, xelatex, lualatex with
-  auto-detection, latexmk backend, texfot log filtering, PDF/A output, and
-  verbosity control (--verbose/--quiet). Empirically optimized scaling: single agent 1-10 pages, split
-  11-20, batch-7 pipeline 21+. Use when user asks to: (1) create a resume/CV/cover
-  letter, (2) write a LaTeX document, (3) create PDF with tables/charts/images,
-  (4) compile a .tex file, (5) make a report/invoice/presentation, (6) anything
-  involving LaTeX or pdflatex, (7) convert/OCR a PDF to LaTeX, (8) convert
-  handwritten notes, (9) create charts/graphs/diagrams, (10) create slides,
-  (11) write a thesis or dissertation, (12) create an academic CV, (13) create
-  a poster, (14) create an exam/quiz, (15) create a book, (16) convert between
-  document formats (Markdown, DOCX, HTML to/from LaTeX), (17) generate Mermaid
-  diagrams for LaTeX, (18) create a formal business letter, (19) create a cheat
-  sheet or reference card, (20) create an exam formula sheet or crib sheet,
-  (21) condense lecture notes/PDFs into a cheat sheet,
-  (22) create a fillable PDF form with text fields/checkboxes/dropdowns,
-  (23) create a document with conditional content/toggles (show/hide sections),
-  (24) generate batch/mail-merge documents from CSV/JSON data,
-  (25) create a version diff PDF (latexdiff) highlighting changes between documents,
-  (26) create a homework or assignment submission with problems and solutions,
-  (27) create a lab report with data tables, graphs, and error analysis,
-  (28) encrypt or password-protect a PDF,
-  (29) merge multiple PDFs into one,
-  (30) optimize/compress a PDF for web or email,
-  (31) lint or check a LaTeX document for common issues,
-  (32) count words in a LaTeX document,
-  (33) analyze document statistics (figures, tables, citations),
-  (34) fetch BibTeX from a DOI,
-  (35) convert a Graphviz .dot file to PDF/PNG,
-  (36) convert a PlantUML .puml file to PDF/PNG,
-  (37) create a one-pager/fact sheet/executive summary,
-  (38) create a datasheet or product specification sheet,
-  (39) extract pages from a PDF (page ranges, odd/even),
-  (40) check LaTeX package availability before compiling,
-  (41) analyze citations and cross-reference with .bib files,
-  (42) debug LaTeX compilation errors,
-  (43) make a document accessible (PDF/A, tagged PDF),
-  (44) create lecture notes or course handouts,
-  (45) fill an existing PDF form (fillable fields or non-fillable with annotations),
-  (46) extract text or tables from a PDF (pdfplumber, pypdf),
-  (47) OCR a scanned PDF to text (pytesseract),
-  (48) create a PDF programmatically with reportlab (Canvas, Platypus),
-  (49) rotate or crop PDF pages (pypdf),
-  (50) add a watermark to an existing PDF,
-  (51) extract metadata from a PDF (title, author, subject).
----
 
 # LaTeX Document Skill
 

--- a/skills/10-Jill0099-causal-inference-mixtape/SKILL.md
+++ b/skills/10-Jill0099-causal-inference-mixtape/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: causal-inference-mixtape
-description: This skill should be used when the user asks to "implement a DiD regression", "write a causal inference pipeline", "set up an event study", "implement instrumental variables", "run a regression discontinuity design", "build a synthetic control model", "implement propensity score matching", "write parallel trends test", "implement Bacon decomposition", or needs code templates for causal inference methods in Python, R, or Stata. Based on Scott Cunningham's Causal Inference: The Mixtape.
+description: "Practitioner-oriented causal inference skill with ready-to-run code templates in Python, R, and Stata covering 10 identification strategies. Use when the user asks to implement a DiD regression, write a causal inference pipeline, set up an event study, implement instrumental variables, run a regression discontinuity design, build a synthetic control model, implement propensity score matching, write parallel trends test, implement Bacon decomposition, or needs code templates for causal inference methods. Based on Scott Cunningham's Causal Inference: The Mixtape."
 version: 1.0.0
 ---
 


### PR DESCRIPTION
Hey @brycewang-stanford 👋

119 repos and 23,000+ skills organized by empirical research workflow from topic selection to journal submission. The ambition of mapping the entire social science research pipeline to agent skills is remarkable. The CoPaper.AI angle of "20 minutes to a reproducible empirical paper" backed by Stanford REAP gives this real academic weight. The StatsPAI integration with 390+ causal inference functions is a standout. Wanted to suggest a few improvements to the SKILL.md.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/96cde64a-6bfa-477a-8ca3-05a6b666a8e9" />


<details>
<summary>Changes made</summary>

### Structural fixes (all affected skills)
- **Moved HTML attribution comments below frontmatter** - the `<!-- CoPaper.AI ... -->` blocks were placed before the opening `---`, breaking YAML frontmatter detection. Moved them to just after the closing `---` so validators can parse the frontmatter while preserving the attribution.
- **Converted chevron (`>`) descriptions to quoted strings** - `latex-document` used a YAML block scalar spanning 57 lines for the description. Condensed to a focused quoted string covering the key use cases.
- **Quoted YAML description strings** - `causal-inference-mixtape` had an unquoted colon (`Causal Inference: The Mixtape`) breaking YAML parsing.

### Content improvements

**statspai** (72% → 85%)
- Added explicit `Use when...` clause for treatment effect estimation, causal analysis, policy evaluation, and observational studies
- Added natural language trigger terms (treatment effect estimation, causal analysis, policy evaluation, observational study) alongside method acronyms
- Replaced promotional comparison table with practical validation/error-handling guidance
- Reframed "Why StatsPAI for Agents?" as actionable "Agent API" section

**literature-review** (5% → 72%)
- Removed duplicated "Screening and Selection" sub-section in Best Practices

**latex-document** (10% → 90%)
- Trimmed description from 57 lines to a focused 4-line summary covering the core use cases

**causal-inference-mixtape** (10% → 82%)
- Restructured description to lead with what the skill provides before listing triggers

</details>

I kept this PR focused on the 5 skills with the biggest improvements to keep the diff reviewable. Happy to follow up with the rest in a separate PR if you'd like.

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

I also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

This means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏