### PR TITLE
Add II-Commons literature retrieval skill

### DIFF
--- a/docs/02-文献检索与综述.md
+++ b/docs/02-文献检索与综述.md
@@ -25,6 +25,16 @@
 | **省时** | 以前关键词换来换去半天筛出十篇，现在一句话十几秒出结果 |
 | **安装** | `clawhub install literature-search` |
 
+### ii-commons（跨语料确定性检索）
+
+| 属性 | 说明 |
+|------|------|
+| **来源** | [Intelligent-Internet/II-Commons-Skills](https://github.com/Intelligent-Internet/II-Commons-Skills) |
+| **功能** | 面向 Agent 的确定性检索 Skill 和 Node.js CLI，覆盖 arXiv、PubMed/PMC，以及支持的美国政策语料 |
+| **工作流** | `cutoff` 查看每日更新语料边界 → 按语料搜索 → 拉取元数据或全文 Markdown → 用稳定 ID 回溯证据 |
+| **适用** | 需要可复现文献检索、公共卫生/政策证据比较、跨 arXiv 与 PubMed 的研究综述 |
+| **安装** | `npx @intelligentinternet/ii-commons --help` 或安装仓库中的 `skills/ii-commons/` |
+
 ### literature-review（文献综述）
 
 | 属性 | 说明 |


### PR DESCRIPTION
Adds II-Commons to the literature search and review skills document.\n\nII-Commons is an open-source agent skill and Node.js CLI for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora. It fits literature search/review workflows that need reproducible searches, corpus freshness cutoffs, metadata lookup, and full-document markdown retrieval.\n\nProject: https://github.com/Intelligent-Internet/II-Commons-Skills