### PR TITLE
feat(aer-skills): SkillOpt-style optimization — add self-verifying gates

### DIFF
--- a/skills/50-brycewang-aer-skills/docs/design-principles.md
+++ b/skills/50-brycewang-aer-skills/docs/design-principles.md
@@ -53,3 +53,7 @@ Each skill in this repository solves one slice. `aer-workflow` exists to compose
 ## 10. English-First, Globally Usable
 
 All skill content is in English so the agent can apply it regardless of the user's primary language. Chinese-language navigation is provided through `README.zh-CN.md` for discoverability.
+
+## 11. Self-Verifying Gates
+
+Every skill ends with a binary, checkable gate — a checklist or a Handoff contract — that the agent must satisfy before declaring the stage done. The skills are self-verifying, not merely advisory. This is the same validation-gate discipline that text-space skill optimizers such as Microsoft SkillOpt use to accept only strictly-improving edits, brought *inside* each skill so an agent can apply it without an external evaluation harness. See `skillopt-optimization.md` for the optimization pass that introduced the missing gates.

--- a/skills/50-brycewang-aer-skills/docs/skillopt-optimization.md
+++ b/skills/50-brycewang-aer-skills/docs/skillopt-optimization.md
@@ -1,0 +1,50 @@
+# SkillOpt-Style Optimization Pass
+
+These skills were reviewed with the discipline behind [Microsoft SkillOpt](https://github.com/microsoft/SkillOpt):
+treat each skill document as a trainable artifact, and accept only **bounded edits that
+strictly improve** it against a clear rubric — never a wholesale rewrite of content that
+already works.
+
+## Rubric applied
+
+A skill is scored on four axes:
+
+1. **Activation** — does the frontmatter `description` fire the skill exactly when it should
+   (third-person, concrete "use when…" triggers, full documented scope)?
+2. **Execution** — are the body instructions concrete, ordered, and free of vague filler?
+3. **Compactness** — every line earns its place; reference-heavy detail lives in `templates/`
+   and `examples/`, loaded on demand.
+4. **Self-verification** — does the skill end with a binary gate the agent can check before
+   handing off? (SkillOpt's validation-gate concept, made local.)
+
+## What this pass changed
+
+The collection already scored high on axes 1–3, so edits were deliberately small and additive:
+
+| Skill | Edit | Axis |
+|---|---|---|
+| `aer-topic-selection` | Added **Go / No-Go Gate** before Handoff | self-verification |
+| `aer-identification` | Added **Identification Gate** before Handoff | self-verification |
+| `aer-robustness` | Added **Coverage Gate** before Handoff | self-verification |
+| `aer-introduction` | Added **Pre-Handoff Gate** before Handoff | self-verification |
+| `aer-rebuttal` | Broadened `description` to cover reject-and-resubmit and conditional acceptance (already in the body) | activation |
+| `docs/design-principles.md` | Added principle #11, *Self-Verifying Gates* | documentation |
+
+Each new gate is **binary and skill-specific**, derived from that skill's own hard rules — it
+is not a restatement of the existing *Anti-Patterns* (narrative warnings) or *Handoff* (a
+reporting contract). The four skills that already shipped explicit checklists
+(`aer-tables-figures`, `aer-submission`, `aer-replication`, `aer-rebuttal`) and the router
+(`aer-workflow`, whose Handoff Contract is its gate) were left unchanged.
+
+After this pass, **all nine sub-skills end with a self-verification mechanism.**
+
+## Reproducing a future optimization loop
+
+To run an actual SkillOpt training loop (rather than this manual pass) against a skill:
+
+1. Define an eval set of held-out tasks for the skill (e.g., real AER intros to compress, real
+   referee reports to triage) with a scorer (word-count gate, rubric LLM-judge, or human label).
+2. Point SkillOpt's optimizer model at the single `SKILL.md` as the trainable state.
+3. Let it propose bounded add/delete/replace edits; **accept only those that raise the held-out
+   score**, exactly as the gates above encode acceptance for the agent at run time.
+4. Deploy the resulting `best_skill.md` in place of the current `SKILL.md`.

--- a/skills/50-brycewang-aer-skills/skills/aer-identification/SKILL.md
+++ b/skills/50-brycewang-aer-skills/skills/aer-identification/SKILL.md
@@ -174,6 +174,16 @@ When working from the AER-skills repository or plugin bundle, load only the rele
 - Staggered DiD implementation: `templates/stata/03_main_did.do`, `templates/r/03_main_did.R`, or `templates/python/main_did.py`
 - Classic design examples: `examples/aer-exemplars.md`
 
+## Identification Gate
+
+Do not advance to robustness or writing until, for the chosen design, **all** are true:
+
+- [ ] A modern estimator is used — no TWFE on staggered data, no first-stage-F-only IV, no high-order-polynomial RDD
+- [ ] Every required diagnostic for the design (see the per-design lists above) is run and reported
+- [ ] Inference matches the design — cluster-robust / AR / wild bootstrap / permutation, not default OLS SEs by reflex
+- [ ] The identifying assumption is stated in one sentence, ready to drop into the introduction
+- [ ] No item in "Red Flags for Referees" is present
+
 ## Handoff
 
 ```text

--- a/skills/50-brycewang-aer-skills/skills/aer-introduction/SKILL.md
+++ b/skills/50-brycewang-aer-skills/skills/aer-introduction/SKILL.md
@@ -129,6 +129,17 @@ If the draft is over 100 words:
 
 When working from the AER-skills repository or plugin bundle, read `examples/intro-example.md` only when the user asks for a model introduction, a concrete before/after rewrite, or abstract compression.
 
+## Pre-Handoff Gate
+
+Ship the introduction only when **all** are true:
+
+- [ ] Abstract ≤ 100 words by actual word count, with most words spent on the result
+- [ ] All five paragraphs present in order — Hook, Question, Identification, Antecedents+Value, Roadmap
+- [ ] Identification strategy named within pages 1-3, not deferred to the methods section
+- [ ] Exactly three (max four) contributions, each meaningful only against the cited antecedents
+- [ ] No "Introduction" heading; the method claim matches the actual estimator
+- [ ] No banned phrasing — "to the best of our knowledge, the first to...", vacuous "we contribute to the literature on..."
+
 ## Handoff
 
 ```text

--- a/skills/50-brycewang-aer-skills/skills/aer-rebuttal/SKILL.md
+++ b/skills/50-brycewang-aer-skills/skills/aer-rebuttal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aer-rebuttal
-description: Use when responding to a Revise & Resubmit decision from AER, AER:Insights, or an AEJ, and a point-by-point response letter plus aligned manuscript revisions are needed. Handles triage, the concede / clarify / push-back decision, and the response-letter format that editors actually read.
+description: Use when responding to any post-review decision from AER, AER:Insights, or an AEJ — Revise & Resubmit, reject-and-resubmit, or conditional acceptance — and a point-by-point response letter plus aligned manuscript revisions are needed. Handles comment triage, the concede / clarify / push-back decision, and the response-letter format that editors actually read.
 ---
 
 # AER Rebuttal

--- a/skills/50-brycewang-aer-skills/skills/aer-robustness/SKILL.md
+++ b/skills/50-brycewang-aer-skills/skills/aer-robustness/SKILL.md
@@ -111,6 +111,17 @@ Keep main-text robustness to **one table** with each row a different specificati
 - Magnitude differences are explained in the text, not left to the reader to compute
 - Sample-size changes across rows are flagged
 
+## Coverage Gate
+
+The empirical section is referee-ready only when **all** are present and theory-motivated (not mined):
+
+- [ ] Robustness spans specification, sample, outcome definition, clustering, and estimator
+- [ ] Heterogeneity is mechanism-predicted (interaction form), labeled pre-specified vs. exploratory
+- [ ] Mechanism shows both channel evidence and explicit ruling-out of the 2-3 leading alternatives
+- [ ] Placebo / falsification covers pre-treatment, cross-unit, and outcome placebo as applicable
+- [ ] Each of the top-5 anticipated referee comments has a visible pre-emption in the paper
+- [ ] Any null is reported with demonstrated power and tight CIs, never over-claimed as "no effect"
+
 ## Handoff
 
 ```text

--- a/skills/50-brycewang-aer-skills/skills/aer-topic-selection/SKILL.md
+++ b/skills/50-brycewang-aer-skills/skills/aer-topic-selection/SKILL.md
@@ -95,6 +95,16 @@ Peer feedback measurably improves journal placement: one SD more comments → 47
 
 Skip none of these for an AER target. AER: Insights tolerates a shorter cycle because the contribution is sharper and the venue is younger.
 
+## Go / No-Go Gate
+
+Advance to `aer-identification` / `aer-introduction` only if **all** hold; otherwise route down (AEJ / field journal) or stop:
+
+- [ ] Contribution sentence written in one line with every blank (X, Y, Z, D, M, Q) filled
+- [ ] All four Top-5 Bar tests evaluated; AER chosen as target only if all four pass
+- [ ] Target venue named explicitly, with a one-sentence reason it is not one tier lower
+- [ ] No kill switch live — no "and we also explore", no "we already knew that", no "interesting but not economics"
+- [ ] At least three subfields that would plausibly cite the paper can be named
+
 ## Handoff
 
 When this skill finishes, emit:


### PR DESCRIPTION
SkillOpt-style optimization of the in-repo **AER-skills** collection (`skills/50-brycewang-aer-skills`). Bounded, strictly-improving edits guided by Microsoft SkillOpt's validation-gate discipline — **no rewrites of already-strong content**:

- Add a binary, skill-specific **self-check gate** before the Handoff block in the four sub-skills that lacked one: `aer-topic-selection` (Go/No-Go Gate), `aer-identification` (Identification Gate), `aer-robustness` (Coverage Gate), `aer-introduction` (Pre-Handoff Gate). **All nine sub-skills now end with a self-verification mechanism.**
- Broaden `aer-rebuttal` description to cover reject-and-resubmit and conditional acceptance (already handled in the body) for correct activation.
- Add design principle #11 (Self-Verifying Gates) and `docs/skillopt-optimization.md` documenting the rubric and a reproducible future SkillOpt training loop.

## Summary

- 4 self-check gates added, 1 description broadened, 1 design principle + 1 optimization-log doc added (net +97/−1 across 7 files in the original change).
- Merged latest `main` (parallel 00.x SkillOpt gate work) and regenerated the catalog so `catalog/*` + `docs/SKILL_CATALOG.md` cover both branches.
- Scope is disjoint from the parallel `00.x` work; `69-Paper-WorkFlow` was audited and intentionally left unchanged (already SkillOpt-optimized, `validate_skill.py` passes, evidence-gated maintenance governance).

## Checklist

- [x] I verified the source repo, license, and install path for any new skill. *(N/A — no new skill; edits the existing in-repo `skills/50-brycewang-aer-skills`, MIT.)*
- [x] I added or updated the relevant `docs/` category entry. *(`make catalog` refreshed `docs/SKILL_CATALOG.md` / `SKILL_QUALITY.md` / `TAXONOMY.md`; added in-collection `docs/skillopt-optimization.md` + design principle #11.)*
- [x] I updated `evals/flagship-evals.json` if this changes a flagship skill or recommended workflow. *(N/A — flagship status unchanged.)*
- [x] I ran `make catalog`.
- [x] I ran `make check`. *(`make validate` ✓, `make test` ✓ 173 tests incl. `test_skillopt_gates.py`, `make python-compat` ✓; full eval/benchmark suite verified by CI.)*
- [x] I avoided adding skills whose core path requires a paid/proprietary API.

## Notes for reviewers

- **Source:** in-repo first-party collection `skills/50-brycewang-aer-skills` (not vendored).
- **License:** MIT (collection `LICENSE`).
- **Local path:** `skills/50-brycewang-aer-skills/`.
- Each new gate is binary and derived from that skill's own hard rules — distinct from the existing *Anti-Patterns* (narrative) and *Handoff* (reporting) blocks.
