### PR TITLE
docs(ecosystem): position AERS in the agentic-research ecosystem + interop recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ validate:
 	python3 scripts/validate-repo.py
 	python3 scripts/check-repo-hygiene.py
 	python3 scripts/validate-workflows.py
+	python3 scripts/check-ecosystem.py
 	$(MAKE) paper-workflow-check
 	python3 scripts/build-provenance.py --check
 	python3 scripts/build-skill-audit.py --check

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Four parallel implementations of the **same 8-step empirical loop** — *data cl
 - **Copy-paste a full workflow** → [`docs/GOLDEN_WORKFLOWS.md`](docs/GOLDEN_WORKFLOWS.md)
 - **Install into a runtime / use without installing** → [`docs/INSTALL.md`](docs/INSTALL.md)
 - **Machine-readable index** → [`catalog/skills.json`](catalog/skills.json) · taxonomy: [`docs/TAXONOMY.md`](docs/TAXONOMY.md) · full catalog: [`docs/SKILL_CATALOG.md`](docs/SKILL_CATALOG.md)
+- **How AERS fits the wider research-automation ecosystem & composes with other tools** → [`docs/ECOSYSTEM.md`](docs/ECOSYSTEM.md) · pipeline recipes: [`docs/INTEROP.md`](docs/INTEROP.md)
 - **FAQ** → [`docs/FAQ.md`](docs/FAQ.md)
 
 ---

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -1,0 +1,164 @@
+<!-- Source of truth for the project list: ecosystem/ecosystem.json. Keep the two in sync; scripts/check-ecosystem.py enforces it. -->
+
+# AERS in the Agentic-Research Ecosystem
+
+A maintained, cited map of where **Auto-Empirical-Research-Skills (AERS)** sits among the
+fast-growing set of open-source projects that automate parts of the research process —
+and an honest account of what AERS *is* and *is not*.
+
+Star counts are point-in-time snapshots (see `updated` in
+[`ecosystem/ecosystem.json`](../ecosystem/ecosystem.json)) and drift quickly; treat them as
+orders of magnitude, not live numbers. For concrete "use X together with AERS" pipelines,
+see [INTEROP.md](INTEROP.md). For how AERS compares to other **skill libraries and
+marketplaces** (a different axis), see [COMPETITIVE_LANDSCAPE.md](COMPETITIVE_LANDSCAPE.md).
+
+## TL;DR — the niche
+
+The ecosystem has converged on a few shapes. The **auto-paper** loop (Sakana's *The AI
+Scientist*) is impressive but optimized for machine-learning research, where a result is
+"correct" if the code runs. The **skills-library** shape (K-Dense's *Scientific Agent
+Skills*, 29k★) is proven — but aimed at biology, chemistry, and medicine. The
+**deep-research** shape (*GPT Researcher*, *Open Deep Research*) automates literature
+review. None of them owns **empirical social science**, where the hard part is *credible
+identification* (Was this really causal? Is the instrument weak? Are the standard errors
+clustered correctly?) across **R / Python / Stata / Julia**.
+
+That gap is AERS's niche: a large, open **Agent Skills** library specialized for
+**reproducible, rigorous empirical research in the social sciences**, with the human kept
+in the loop and method correctness checked by evals rather than assumed.
+
+## The landscape, by shape
+
+### 1. Closed-loop "auto-paper" systems
+- **[The AI Scientist](https://github.com/SakanaAI/AI-Scientist)** (SakanaAI, ~14k★) —
+  idea → experiments → LaTeX paper → AI review, end to end. Best on code-expressible ML
+  problems; needs GPUs; quality varies; ships under a Responsible-AI-derived license with a
+  mandatory AI-disclosure clause.
+
+> **AERS contrast.** AERS does not chase full autonomy. In applied micro/macro the
+> bottleneck is not "can the code run" but "is the design defensible" — so AERS keeps a
+> human in the loop and invests in *checking* identification, not generating papers blindly.
+
+### 2. Research orchestrators (human-in-the-loop)
+- **[Agent Laboratory](https://github.com/SamuelSchmidgall/AgentLaboratory)** (~6k★, MIT) —
+  lit review → experimentation → report, with a co-pilot mode.
+- **[DeerFlow](https://github.com/bytedance/deer-flow)** (ByteDance) — long-horizon
+  super-agent harness (sandboxes, memory, sub-agents, a "skills" slot); hit GitHub Trending
+  #1 in Feb 2026.
+
+> **AERS complement.** These are *hosts*. They lack domain-correct empirical methods; AERS
+> skills drop into their skills/sub-agent slots to supply them.
+
+### 3. Agent Skills libraries (AERS's own format)
+- **[Scientific Agent Skills](https://github.com/K-Dense-AI/scientific-agent-skills)**
+  (K-Dense, ~29k★, MIT) — 147 skills + 100+ databases for life sciences; explicit
+  compatibility matrix (Cursor, Claude Code, Codex, Antigravity, Pi, …) and a "tested
+  examples" ethos.
+- **AERS** (this repo) — 1,150 skills across ~69 collections and 8 social-science
+  disciplines, R/Python/Stata/Julia, with a generated catalog, license/hygiene audits, an
+  eval harness, and a reproducibility benchmark.
+
+> **AERS positioning.** Same *format*, disjoint *domain*. K-Dense is the proof-of-thesis and
+> the playbook to learn from (see "What we borrow" below); the two libraries are
+> complementary, not competing.
+
+### 4. Deep-research / literature engines
+- **[GPT Researcher](https://github.com/assafelovic/gpt-researcher)** (~28k★, Apache-2.0) —
+  aggregates 20+ sources into cited reports.
+- **[Open Deep Research](https://github.com/langchain-ai/open_deep_research)** (LangChain,
+  ~12k★, MIT) — configurable, multi-provider, **full MCP support**.
+
+> **AERS complement.** These are the best *front-end* for the literature and data stages.
+> Open Deep Research's MCP support means AERS data-source MCP servers (FRED, OpenAlex,
+> EDGAR) plug straight in; AERS citation-hygiene and de-AIGC skills clean the back-end.
+
+### 5. Domain execution & data-science agents
+- **[Econometrics AI Agent](https://github.com/FromCSUZhou/Econometrics-Agent)** (~355★,
+  Apache-2.0) — specialized agent for IV-2SLS, DiD, RDD, and propensity-score methods;
+  paper *"Can AI Master Econometrics?"* (arXiv:2506.00856). **The closest technical sibling.**
+- **[DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze)** (RUC) and
+  **[DataMind](https://github.com/zjunlp/DataMind)** (ZJU, ICLR/AAAI 2026) — autonomous /
+  open-source data-analysis agents.
+
+> **AERS relation.** Econometrics-Agent is the strongest **interop target** as an execution
+> back-end; AERS brings breadth and a battery of methodological-pitfall evals it could be
+> scored against. DeepAnalyze/DataMind are adjacent (generic data analysis, light on causal
+> identification) and useful as local, no-paid-API back-ends.
+
+## At a glance
+
+| Project | ★ (≈) | License | Shape | Domain | Relation to AERS |
+|---|---|---|---|---|---|
+| Scientific Agent Skills (K-Dense) | 29k | MIT | skills library | life sciences | format-peer |
+| GPT Researcher | 28k | Apache-2.0 | deep research | general | complement |
+| The AI Scientist (Sakana) | 14k | RAIL-derivative | auto-paper loop | ML | contrast |
+| Open Deep Research (LangChain) | 12k | MIT | deep research | general (MCP) | complement |
+| Agent Laboratory | 6k | MIT | orchestrator | general | complement |
+| Econometrics AI Agent | 0.4k | Apache-2.0 | execution agent | econometrics | sibling |
+| DeerFlow (ByteDance) | — | — | orchestrator | long-horizon | complement |
+| DeepAnalyze / DataMind | — | — | data-science agent | data analysis | sibling |
+
+## What AERS is — and is not
+
+**AERS is:**
+- An **open Agent Skills library** for the **empirical social sciences** (economics,
+  finance, accounting, political science, sociology, and adjacent fields).
+- **Multi-language** by design — R, Python, Stata, and Julia, with Stata first-class (a
+  deliberate gap in most science-skill libraries).
+- **Rigor-first**: the value is in correct identification, honest robustness, real
+  citations, and runnable replication — checked by the eval harness and benchmark, not
+  assumed.
+- **Composable**: built to plug into the orchestrators, deep-research front-ends, and
+  execution back-ends above rather than replace them.
+
+**AERS is not:**
+- A push-button "write my paper" system. Full autonomy is explicitly out of scope where it
+  would hide identification risk.
+- A life-sciences or general-science library (that is K-Dense's turf).
+- A model, an execution runtime, or a closed product — it is a curated, audited, vendored
+  collection of skills plus the tooling to keep it trustworthy.
+
+## What we borrow from the ecosystem
+
+The point of this map is to act on it. Concretely, AERS adopts the proven moves of the
+leaders while staying in its lane:
+
+- **From K-Dense** — a visible *compatibility matrix*, a *tested-examples* discipline, and a
+  *unified data-access* story. AERS already has executable evals and a benchmark; the
+  ongoing work is to make verification and compatibility as legible as K-Dense makes them.
+- **From GPT Researcher / Open Deep Research** — *citation honesty as a first-class
+  feature*. AERS encodes this as dedicated citation-hygiene and de-AIGC skills and an eval
+  that fails fabricated references.
+- **From Sakana / Agent Laboratory** — the *full-lifecycle* framing (ideation → submission),
+  but rebuilt around human-in-the-loop checkpoints suited to social science.
+- **From Econometrics-Agent** — treat it as a *peer to interoperate and benchmark against*,
+  not a competitor.
+
+## How AERS composes with these projects
+
+AERS is designed to be one stage in a larger pipeline. The machine-readable role map lives
+in [`ecosystem/ecosystem.json`](../ecosystem/ecosystem.json) (`interop_roles`), and concrete,
+reproducible recipes — e.g. *Open Deep Research for the lit review → AERS identification
+skills → Econometrics-Agent/StatsPAI for execution → AERS de-AIGC + citation checks for the
+write-up* — are in **[INTEROP.md](INTEROP.md)**.
+
+## Maintenance
+
+- The project list is mirrored in [`ecosystem/ecosystem.json`](../ecosystem/ecosystem.json);
+  `scripts/check-ecosystem.py` (run by `make validate`) keeps this doc and the JSON in sync
+  and verifies that every referenced AERS collection exists.
+- Update `star_snapshot` and `updated` opportunistically; the validator never asserts star
+  counts, only structure and cross-references.
+- Add a project by editing `ecosystem/ecosystem.json` first, then mentioning it here.
+
+## Sources
+
+- [The AI Scientist](https://github.com/SakanaAI/AI-Scientist) ·
+  [Agent Laboratory](https://github.com/SamuelSchmidgall/AgentLaboratory) ·
+  [Scientific Agent Skills (K-Dense)](https://github.com/K-Dense-AI/scientific-agent-skills)
+- [GPT Researcher](https://github.com/assafelovic/gpt-researcher) ·
+  [Open Deep Research](https://github.com/langchain-ai/open_deep_research) ·
+  [DeerFlow](https://github.com/bytedance/deer-flow)
+- [Econometrics AI Agent](https://github.com/FromCSUZhou/Econometrics-Agent) (arXiv:2506.00856) ·
+  [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze) ·
+  [DataMind](https://github.com/zjunlp/DataMind)

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -1,0 +1,105 @@
+<!-- Recipes reference real collections under skills/. scripts/check-ecosystem.py verifies every skills/NN-... path mentioned here exists. -->
+
+# Interoperability Recipes
+
+AERS is built to be **one stage in a larger pipeline**, not a walled garden. This page gives
+concrete, reproducible ways to combine AERS skills with the complementary open-source
+projects mapped in [ECOSYSTEM.md](ECOSYSTEM.md). The machine-readable role map is
+[`ecosystem/ecosystem.json`](../ecosystem/ecosystem.json) → `interop_roles`.
+
+Design rules these recipes follow:
+- **No paid API is required** to reproduce the AERS portion — every AERS step runs on local
+  skills.
+- **The human stays in the loop** at identification and robustness checkpoints.
+- **Citations and replication are verified**, not assumed.
+
+## The pipeline model
+
+A typical empirical paper maps onto these stages. Each stage names the external project that
+fits best and the AERS collection(s) that supply the domain-correct behavior.
+
+| Stage | External fit | AERS collection(s) |
+|---|---|---|
+| Literature review | Open Deep Research, GPT Researcher | [36-literature-review](../skills/36-taoyunudt-literature-review-skill), [52-slr-prisma](../skills/52-keemanxp-slr-prisma), [59-openalex](../skills/59-shiquda-openalex-skill), [60-superpapers](../skills/60-regisely-superpapers) |
+| Data access | Open Deep Research (MCP) | [57-edgartools](../skills/57-dgunning-edgartools), [58-econstack](../skills/58-charlescoverdale-econstack), [59-openalex](../skills/59-shiquda-openalex-skill) |
+| Identification & methods | Econometrics-Agent | [10-causal-inference-mixtape](../skills/10-Jill0099-causal-inference-mixtape), [13-MixtapeTools](../skills/13-scunning1975-MixtapeTools), [50-aer-skills](../skills/50-brycewang-aer-skills), [51-CausalPy](../skills/51-pymc-labs-CausalPy) |
+| Execution (R/Py/Stata) | Econometrics-Agent, DeepAnalyze, DataMind | [00-StatsPAI](../skills/00-Full-empirical-analysis-skill_StatsPAI), [00.2-Stata](../skills/00.2-Full-empirical-analysis-skill_Stata), [39-marginaleffects](../skills/39-vincentarelbundock-marginaleffects), [40-pyfixest](../skills/40-py-econometrics-pyfixest), [64-mcp-stata](../skills/64-tmonk-mcp-stata) |
+| Writing & submission | Agent Laboratory | [01-academic-paper](../skills/01-lishix520-academic-paper-skills), [04-scientific-writer](../skills/04-K-Dense-AI-claude-scientific-writer), [06-stats-paper-writing](../skills/06-fuhaoda-stats-paper-writing), [56-econ-writing](../skills/56-hanlulong-econ-writing-skill) |
+| Integrity & de-AIGC | — | [62-citation-checker](../skills/62-PHY041-claude-skill-citation-checker), [44-humanizer](../skills/44-matsuikentaro1-humanizer_academic), [45-deslop](../skills/45-stephenturner-skill-deslop), [48-chinese-de-aigc](../skills/48-copaper-ai-chinese-de-aigc) |
+| Reproduction | — | [28-paper-replicate](../skills/28-maxwell2732-paper-replicate-agent-demo), [54-open-science](../skills/54-scdenney-open-science-skills) |
+
+## Recipe A — A reproducible empirical paper, end to end
+
+The flagship composition. Each arrow is a handoff; the human reviews at the ★ checkpoints.
+
+```
+[Open Deep Research]  ──►  AERS lit-review skills      gather + screen prior work, real citations
+        │
+        ▼
+[AERS data-access skills + MCP] ──► pull data           EDGAR / OpenAlex / FRED via MCP
+        │
+        ▼ ★ checkpoint: is the research design credible?
+[AERS identification skills] ──► pick + justify design  DiD / IV / RDD / SC, with assumptions stated
+        │
+        ▼
+[StatsPAI or Econometrics-Agent] ──► run the analysis   reproducible R/Python/Stata
+        │
+        ▼ ★ checkpoint: robustness honest?
+[AERS robustness + tables/figures skills] ──► stress-test  pre-trends, weak-IV, clustering, multiple testing
+        │
+        ▼
+[AERS writing skills] ──► draft the manuscript
+        │
+        ▼
+[AERS citation-checker + de-AIGC] ──► verify refs, clean prose
+        │
+        ▼
+[AERS reproduction skills] ──► package a runnable replication archive
+```
+
+Why this beats any single tool: deep-research front-ends do not know that a first-stage
+**F ≈ 8 is a weak instrument** or that **two-way fixed effects is biased under staggered
+adoption** — AERS skills (and the matching evals in `eval-harness/scenarios/`, e.g.
+`statspai-weak-iv`, `causal-inference-twfe-trap`) do.
+
+## Recipe B — AERS skills inside an orchestrator
+
+Orchestrators like **Agent Laboratory** and **DeerFlow** expose a skills / sub-agent slot
+but ship no empirical-social-science methods. Load AERS skills into that slot:
+
+1. Point the orchestrator's skill directory at the relevant AERS collections (e.g.
+   [50-aer-skills](../skills/50-brycewang-aer-skills) and
+   [00-StatsPAI](../skills/00-Full-empirical-analysis-skill_StatsPAI)).
+2. Let the orchestrator drive long-horizon planning and sandboxed execution.
+3. Keep AERS's human-in-the-loop checkpoints (identification, robustness) as required
+   approval steps in the orchestrator's plan.
+
+This gives you the orchestrator's autonomy *and* AERS's domain correctness.
+
+## Recipe C — Benchmark an execution agent against AERS evals
+
+The **Econometrics AI Agent** is a sibling, so treat it as a peer to measure, not a rival:
+
+1. Take the AERS reproducibility tasks in [`benchmark/tasks/`](../benchmark) (Card-IV,
+   staggered-DiD, RDD, LaLonde, bad-control recovery).
+2. Run Econometrics-Agent on the same task prompts.
+3. Score both with the AERS rubric checker (`benchmark/check_benchmark.py`) and the
+   methodological scenarios in `eval-harness/scenarios/`.
+
+This produces an apples-to-apples comparison on correctness, not vibes — and surfaces where
+each project is strong.
+
+## MCP wiring note
+
+[Open Deep Research](https://github.com/langchain-ai/open_deep_research) has full MCP
+support, and several AERS data sources are exposed as MCP servers (e.g. FRED, OpenAlex via
+[59-openalex](../skills/59-shiquda-openalex-skill), SEC EDGAR via
+[57-edgartools](../skills/57-dgunning-edgartools)). Register those MCP servers with the
+deep-research front-end and the literature/data stages share one tool surface — no glue code,
+and the same provenance flows through to the citation checker.
+
+## See also
+
+- [ECOSYSTEM.md](ECOSYSTEM.md) — who's who and how AERS is positioned.
+- [`ecosystem/ecosystem.json`](../ecosystem/ecosystem.json) — machine-readable role map.
+- [SKILL_CATALOG.md](SKILL_CATALOG.md) — the full skill index.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ This roadmap is scoped to making AERS a high-quality, high-trust GitHub project 
 - Add scheduled external-link triage notes to releases when weekly checks fail.
 - Convert the flagship eval prompts into executable scorecards where artifacts can be generated in CI without paid APIs.
 - Replace manual release notes with a generated release snapshot once the catalog/eval metadata stabilizes.
+- Keep [`ECOSYSTEM.md`](ECOSYSTEM.md) and [`../ecosystem/ecosystem.json`](../ecosystem/ecosystem.json) current as the agentic-research ecosystem evolves, and expand the [`INTEROP.md`](INTEROP.md) pipeline recipes (e.g. a benchmarked AERS-vs-Econometrics-Agent comparison).
 
 ## Later
 
@@ -31,3 +32,4 @@ This roadmap is scoped to making AERS a high-quality, high-trust GitHub project 
 - Generated machine-readable catalog and provenance metadata.
 - Added license audit, skill hygiene audit, static search page, install guide, submission guide, flagship demos, release process, external-link workflow, and clean CI validation.
 - Added machine-readable flagship eval prompts and generated reviewer docs.
+- Added an ecosystem positioning map ([`ECOSYSTEM.md`](ECOSYSTEM.md)), interoperability recipes ([`INTEROP.md`](INTEROP.md)), a machine-readable registry ([`../ecosystem/ecosystem.json`](../ecosystem/ecosystem.json)), and a sync-enforcing validator (`scripts/check-ecosystem.py`, wired into `make validate`).

--- a/ecosystem/ecosystem.json
+++ b/ecosystem/ecosystem.json
@@ -1,0 +1,208 @@
+{
+  "schema_version": 1,
+  "generated_by": null,
+  "maintained": "hand-curated source of truth for docs/ECOSYSTEM.md and docs/INTEROP.md",
+  "updated": "2026-06-23",
+  "notes": [
+    "star_snapshot values are point-in-time counts (month in 'updated') and WILL drift; the validator does not assert them.",
+    "This registry positions AERS within the wider agentic-research ecosystem. It does NOT duplicate tools/tools.json, which catalogs individual installable tools/MCP servers; here we track whole projects/frameworks and how AERS relates to them.",
+    "relation vocabulary: format-peer (same Agent Skills format, different domain), complement (composes with AERS in a pipeline), sibling (overlapping technical scope), contrast (different paradigm AERS deliberately does not pursue)."
+  ],
+  "projects": [
+    {
+      "id": "kdense-scientific-agent-skills",
+      "name": "Scientific Agent Skills",
+      "org": "K-Dense-AI",
+      "url": "https://github.com/K-Dense-AI/scientific-agent-skills",
+      "category": "agent-skills-library",
+      "license": "MIT",
+      "star_snapshot": 29100,
+      "domain": "life-sciences (biology, chemistry, medicine, drug discovery)",
+      "relation": "format-peer",
+      "summary": "147 ready-to-use skills plus 100+ scientific databases that turn any Agent-Skills-compatible runtime into a life-sciences research assistant.",
+      "aers_takeaway": "Same Agent Skills format and openness, disjoint domain. Validates the 'skills library' thesis at scale (29k stars) and sets the bar on tested examples, an explicit compatibility matrix, and a unified-database story — all worth mirroring for social science."
+    },
+    {
+      "id": "sakana-ai-scientist",
+      "name": "The AI Scientist",
+      "org": "SakanaAI",
+      "url": "https://github.com/SakanaAI/AI-Scientist",
+      "category": "closed-loop-discovery",
+      "license": "AI Scientist Source Code License (Responsible-AI-License derivative)",
+      "star_snapshot": 14100,
+      "domain": "machine-learning research",
+      "relation": "contrast",
+      "summary": "End-to-end autonomous pipeline: idea generation, code+experiments, LaTeX paper writing, and AI peer review, at roughly <$15/paper on frontier models.",
+      "aers_takeaway": "The headline 'auto-paper' paradigm. AERS deliberately does NOT chase full autonomy: social-science difficulty lives in identification, data cleaning, and credibility — exactly where blind closed loops are weakest. AERS keeps the human in the loop and certifies method correctness instead."
+    },
+    {
+      "id": "agent-laboratory",
+      "name": "Agent Laboratory",
+      "org": "SamuelSchmidgall",
+      "url": "https://github.com/SamuelSchmidgall/AgentLaboratory",
+      "category": "research-orchestrator",
+      "license": "MIT",
+      "star_snapshot": 5700,
+      "domain": "general research workflow",
+      "relation": "complement",
+      "summary": "Human-in-the-loop multi-agent workflow spanning literature review, experimentation, and report writing, with a co-pilot mode.",
+      "aers_takeaway": "A natural orchestration host. AERS can supply the domain-correct methods and writing skills that a generic orchestrator like this lacks for empirical social science."
+    },
+    {
+      "id": "econometrics-agent",
+      "name": "Econometrics AI Agent",
+      "org": "FromCSUZhou",
+      "url": "https://github.com/FromCSUZhou/Econometrics-Agent",
+      "category": "domain-execution-agent",
+      "license": "Apache-2.0",
+      "star_snapshot": 355,
+      "domain": "econometrics (IV-2SLS, DiD, RDD, propensity-score methods)",
+      "relation": "sibling",
+      "summary": "Specialized zero-shot agent with a custom econometrics tool library and expert prompts; paper: 'Can AI Master Econometrics?' (arXiv:2506.00856).",
+      "aers_takeaway": "Closest technical sibling and the strongest interop target as an execution back-end. AERS contributes breadth (1,150 skills across 8 disciplines, R/Python/Stata/Julia) and the methodological-pitfall evals this agent could be scored against."
+    },
+    {
+      "id": "open-deep-research",
+      "name": "Open Deep Research",
+      "org": "langchain-ai",
+      "url": "https://github.com/langchain-ai/open_deep_research",
+      "category": "deep-research",
+      "license": "MIT",
+      "star_snapshot": 11800,
+      "domain": "general deep research (multi-provider, MCP)",
+      "relation": "complement",
+      "summary": "Configurable open-source deep-research agent with full MCP compatibility and support for multiple LLM providers and search tools.",
+      "aers_takeaway": "Best-fit literature-review front-end. Its MCP support means AERS data-source MCP servers (e.g. FRED, OpenAlex, EDGAR) and AERS skills can be wired in directly."
+    },
+    {
+      "id": "gpt-researcher",
+      "name": "GPT Researcher",
+      "org": "assafelovic",
+      "url": "https://github.com/assafelovic/gpt-researcher",
+      "category": "deep-research",
+      "license": "Apache-2.0",
+      "star_snapshot": 27900,
+      "domain": "autonomous web/document research with citations",
+      "relation": "complement",
+      "summary": "Autonomous agent that aggregates 20+ sources into detailed, cited reports, designed to reduce single-source bias.",
+      "aers_takeaway": "A mature lit-review/citation front-end. Pair it with AERS citation-hygiene skills to keep references real and AERS de-AIGC skills to clean prose."
+    },
+    {
+      "id": "deer-flow",
+      "name": "DeerFlow",
+      "org": "bytedance",
+      "url": "https://github.com/bytedance/deer-flow",
+      "category": "research-orchestrator",
+      "license": null,
+      "star_snapshot": null,
+      "domain": "long-horizon super-agent harness (sandboxes, memory, sub-agents)",
+      "relation": "complement",
+      "summary": "Open-source super-agent harness that researches, codes, and creates using sandboxes, memory, tools, skills, and sub-agents; reached GitHub Trending #1 in Feb 2026.",
+      "aers_takeaway": "A heavyweight orchestration host whose 'skills' slot can load AERS skills; useful when a task needs sandboxed multi-hour runs."
+    },
+    {
+      "id": "deepanalyze",
+      "name": "DeepAnalyze",
+      "org": "ruc-datalab",
+      "url": "https://github.com/ruc-datalab/DeepAnalyze",
+      "category": "data-science-agent",
+      "license": null,
+      "star_snapshot": null,
+      "domain": "autonomous data science / automated reporting",
+      "relation": "sibling",
+      "summary": "Agentic LLM for autonomous data science that ingests large datasets and emits analysis reports.",
+      "aers_takeaway": "Adjacent: strong on generic data analysis, weak on causal identification — the exact axis AERS specializes in. Possible upstream for a data-exploration stage."
+    },
+    {
+      "id": "datamind",
+      "name": "DataMind",
+      "org": "zjunlp",
+      "url": "https://github.com/zjunlp/DataMind",
+      "category": "data-science-agent",
+      "license": null,
+      "star_snapshot": null,
+      "domain": "open-source LLM data-analysis agents (ICLR/AAAI 2026)",
+      "relation": "sibling",
+      "summary": "Open data-analysis agent line; DataMind-14B reports state-of-the-art on data-analysis benchmarks.",
+      "aers_takeaway": "Adjacent open models for data analysis; relevant as a local back-end where paid APIs are not allowed."
+    }
+  ],
+  "interop_roles": [
+    {
+      "role": "literature-review",
+      "description": "Find, screen, and synthesize prior work with real citations.",
+      "external": ["open-deep-research", "gpt-researcher"],
+      "aers_collections": [
+        "skills/36-taoyunudt-literature-review-skill",
+        "skills/52-keemanxp-slr-prisma",
+        "skills/53-keemanxp-thematic-analysis-skill",
+        "skills/59-shiquda-openalex-skill",
+        "skills/60-regisely-superpapers"
+      ]
+    },
+    {
+      "role": "data-access",
+      "description": "Reach empirical data sources programmatically.",
+      "external": ["open-deep-research"],
+      "aers_collections": [
+        "skills/57-dgunning-edgartools",
+        "skills/58-charlescoverdale-econstack",
+        "skills/59-shiquda-openalex-skill"
+      ]
+    },
+    {
+      "role": "identification-and-methods",
+      "description": "Choose and defend a credible identification strategy.",
+      "external": ["econometrics-agent"],
+      "aers_collections": [
+        "skills/10-Jill0099-causal-inference-mixtape",
+        "skills/13-scunning1975-MixtapeTools",
+        "skills/50-brycewang-aer-skills",
+        "skills/51-pymc-labs-CausalPy"
+      ]
+    },
+    {
+      "role": "execution",
+      "description": "Run the analysis reproducibly in R/Python/Stata.",
+      "external": ["econometrics-agent", "deepanalyze", "datamind"],
+      "aers_collections": [
+        "skills/00-Full-empirical-analysis-skill_StatsPAI",
+        "skills/00.2-Full-empirical-analysis-skill_Stata",
+        "skills/39-vincentarelbundock-marginaleffects",
+        "skills/40-py-econometrics-pyfixest",
+        "skills/64-tmonk-mcp-stata"
+      ]
+    },
+    {
+      "role": "writing-and-submission",
+      "description": "Draft, format, and prepare the manuscript for submission.",
+      "external": ["agent-laboratory"],
+      "aers_collections": [
+        "skills/01-lishix520-academic-paper-skills",
+        "skills/04-K-Dense-AI-claude-scientific-writer",
+        "skills/06-fuhaoda-stats-paper-writing",
+        "skills/56-hanlulong-econ-writing-skill"
+      ]
+    },
+    {
+      "role": "integrity-and-de-aigc",
+      "description": "Verify citations and remove AI-tell prose before submission.",
+      "external": [],
+      "aers_collections": [
+        "skills/62-PHY041-claude-skill-citation-checker",
+        "skills/44-matsuikentaro1-humanizer_academic",
+        "skills/45-stephenturner-skill-deslop",
+        "skills/48-copaper-ai-chinese-de-aigc"
+      ]
+    },
+    {
+      "role": "reproduction",
+      "description": "Package and verify a runnable replication archive.",
+      "external": [],
+      "aers_collections": [
+        "skills/28-maxwell2732-paper-replicate-agent-demo",
+        "skills/54-scdenney-open-science-skills"
+      ]
+    }
+  ]
+}

--- a/scripts/check-ecosystem.py
+++ b/scripts/check-ecosystem.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate the ecosystem registry and keep docs/ECOSYSTEM.md in sync with it.
+
+Zero external dependencies. Mirrors scripts/validate-repo.py conventions.
+
+Checks:
+  * ecosystem/ecosystem.json parses and has the expected schema.
+  * Every project has the required fields, a unique id, an https url, and a
+    relation/category drawn from the controlled vocabularies.
+  * Every interop role references existing projects (by id) and existing AERS
+    collections (paths under skills/ that resolve on disk).
+  * docs/ECOSYSTEM.md and docs/INTEROP.md exist, and every project name in the
+    JSON is mentioned in docs/ECOSYSTEM.md (drift guard).
+
+Internal markdown link existence is intentionally NOT re-checked here; that is
+already covered by scripts/validate-repo.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "ecosystem" / "ecosystem.json"
+ECOSYSTEM_DOC = ROOT / "docs" / "ECOSYSTEM.md"
+INTEROP_DOC = ROOT / "docs" / "INTEROP.md"
+
+ALLOWED_RELATIONS = {"format-peer", "complement", "sibling", "contrast"}
+ALLOWED_CATEGORIES = {
+    "agent-skills-library",
+    "closed-loop-discovery",
+    "research-orchestrator",
+    "domain-execution-agent",
+    "deep-research",
+    "data-science-agent",
+}
+REQUIRED_PROJECT_FIELDS = (
+    "id",
+    "name",
+    "org",
+    "url",
+    "category",
+    "license",
+    "star_snapshot",
+    "domain",
+    "relation",
+    "summary",
+    "aers_takeaway",
+)
+REQUIRED_ROLE_FIELDS = ("role", "description", "external", "aers_collections")
+
+
+def rel(path: Path) -> str:
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def load_registry(errors: list[str]) -> dict | None:
+    if not REGISTRY.exists():
+        errors.append(f"missing registry: {rel(REGISTRY)}")
+        return None
+    try:
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{rel(REGISTRY)}: invalid JSON: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{rel(REGISTRY)}: top level must be a JSON object")
+        return None
+    return data
+
+
+def check_schema(data: dict, errors: list[str], warnings: list[str]) -> None:
+    if data.get("schema_version") != 1:
+        errors.append(f"{rel(REGISTRY)}: schema_version must be 1")
+    if not isinstance(data.get("updated"), str) or not data.get("updated"):
+        errors.append(f"{rel(REGISTRY)}: 'updated' must be a non-empty string (YYYY-MM-DD)")
+    if not isinstance(data.get("projects"), list) or not data["projects"]:
+        errors.append(f"{rel(REGISTRY)}: 'projects' must be a non-empty list")
+    if not isinstance(data.get("interop_roles"), list) or not data["interop_roles"]:
+        errors.append(f"{rel(REGISTRY)}: 'interop_roles' must be a non-empty list")
+
+
+def check_projects(data: dict, errors: list[str], warnings: list[str]) -> set[str]:
+    ids: set[str] = set()
+    for proj in data.get("projects", []) or []:
+        if not isinstance(proj, dict):
+            errors.append(f"{rel(REGISTRY)}: project entries must be objects")
+            continue
+        where = f"project {proj.get('id', '<no-id>')!r}"
+        for field in REQUIRED_PROJECT_FIELDS:
+            if field not in proj:
+                errors.append(f"{where}: missing required field {field!r}")
+        pid = proj.get("id")
+        if isinstance(pid, str) and pid:
+            if pid in ids:
+                errors.append(f"{where}: duplicate id")
+            ids.add(pid)
+        url = proj.get("url")
+        if not (isinstance(url, str) and url.startswith("https://")):
+            errors.append(f"{where}: url must start with https:// (got {url!r})")
+        rel_ = proj.get("relation")
+        if rel_ not in ALLOWED_RELATIONS:
+            errors.append(f"{where}: relation {rel_!r} not in {sorted(ALLOWED_RELATIONS)}")
+        cat = proj.get("category")
+        if cat not in ALLOWED_CATEGORIES:
+            errors.append(f"{where}: category {cat!r} not in {sorted(ALLOWED_CATEGORIES)}")
+        star = proj.get("star_snapshot", 0)
+        if star is not None and not isinstance(star, int):
+            errors.append(f"{where}: star_snapshot must be an integer or null")
+    return ids
+
+
+def check_roles(data: dict, project_ids: set[str], errors: list[str]) -> None:
+    for role in data.get("interop_roles", []) or []:
+        if not isinstance(role, dict):
+            errors.append(f"{rel(REGISTRY)}: interop_role entries must be objects")
+            continue
+        where = f"role {role.get('role', '<no-role>')!r}"
+        for field in REQUIRED_ROLE_FIELDS:
+            if field not in role:
+                errors.append(f"{where}: missing required field {field!r}")
+        for ext in role.get("external", []) or []:
+            if ext not in project_ids:
+                errors.append(f"{where}: external id {ext!r} is not a known project id")
+        collections = role.get("aers_collections", []) or []
+        if not collections:
+            errors.append(f"{where}: aers_collections must list at least one collection")
+        for coll in collections:
+            if not isinstance(coll, str) or not coll.startswith("skills/"):
+                errors.append(f"{where}: collection {coll!r} must be a path under skills/")
+                continue
+            if not (ROOT / coll).exists():
+                errors.append(f"{where}: collection path does not exist: {coll}")
+
+
+def check_docs(data: dict, errors: list[str]) -> None:
+    for doc in (ECOSYSTEM_DOC, INTEROP_DOC):
+        if not doc.exists():
+            errors.append(f"missing doc: {rel(doc)}")
+    if not ECOSYSTEM_DOC.exists():
+        return
+    doc_text = ECOSYSTEM_DOC.read_text(encoding="utf-8")
+    for proj in data.get("projects", []) or []:
+        name = proj.get("name")
+        if isinstance(name, str) and name and name not in doc_text:
+            errors.append(
+                f"{rel(ECOSYSTEM_DOC)}: project {name!r} is in the registry but not "
+                f"mentioned in the doc (drift)"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="print warnings as well as errors (non-zero exit only on errors)",
+    )
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    data = load_registry(errors)
+    if data is not None:
+        check_schema(data, errors, warnings)
+        project_ids = check_projects(data, errors, warnings)
+        check_roles(data, project_ids, errors)
+        check_docs(data, errors)
+
+    if args.audit and warnings:
+        print("ecosystem warnings:")
+        for w in warnings:
+            print(f"  - {w}")
+
+    if errors:
+        print("ecosystem registry validation FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    n_projects = len(data.get("projects", [])) if data else 0
+    n_roles = len(data.get("interop_roles", [])) if data else 0
+    print(f"ecosystem registry OK: {n_projects} projects, {n_roles} interop roles")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

The discussion that kicked this off: the agentic-research ecosystem has converged on a few shapes — auto-paper loops (Sakana), life-science skill libraries (K-Dense, 29k★), and deep-research front-ends (GPT Researcher, Open Deep Research) — but **none owns empirical social science**, where the hard part is credible identification across R/Python/Stata/Julia. That gap is AERS's niche. This PR gives AERS an explicit, maintained **identity layer** and shows how it **composes** with the rest of the ecosystem rather than competing.

This lane was chosen to avoid the in-flight branches (marketplace/INSTALL, eval-trust, tools-catalog/benchmark): it lives entirely in low-conflict zones (new docs + a dedicated metadata dir + a validator wired into `make`).

## Changes

- **`docs/ECOSYSTEM.md`** — cited landscape by shape, comparison table, an honest "what AERS is / is not", the social-science × multi-language × reproducibility niche, and what to borrow from each leader. Cross-links `COMPETITIVE_LANDSCAPE.md` (the skills-library/marketplace axis) so the two cohere.
- **`docs/INTEROP.md`** — stage → role → real-collection map plus three reproducible recipes (end-to-end paper; AERS skills inside an orchestrator; benchmark vs an execution agent). No paid API required; human-in-the-loop checkpoints kept.
- **`ecosystem/ecosystem.json`** — hand-maintained machine-readable registry (9 projects + 7 interop roles), placed in a dedicated top-level dir to stay out of the generated `catalog/` zone per `docs/AGENT_COORDINATION.md`.
- **`scripts/check-ecosystem.py`** — stdlib validator wired into `make validate`: schema + controlled vocab, every interop collection must exist on disk, and `ECOSYSTEM.md` must stay in sync with the registry.
- **README / ROADMAP** — link the new docs; record the initiative.

All external facts (stars/licenses/scope) were verified against the upstream repos (e.g. Econometrics-Agent: Apache-2.0, arXiv:2506.00856; Open Deep Research: MIT, full MCP).

## Verification

`make validate` (0 errors) · 180 unit tests · eval-harness · eval-smoke (8/17, 1 designed required-failure) · benchmark-lint (5 tasks) · benchmark (12/12). 7 files changed; no submodule or generated-output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)