### PR TITLE
feat(rigor): re-land the 5 method-specific eval scenarios missed by #34's squash

### DIFF
--- a/docs/RIGOR_COVERAGE.md
+++ b/docs/RIGOR_COVERAGE.md
@@ -9,7 +9,7 @@ What rigor does AERS actually test, per method family? This map joins three laye
 - **Eval scenarios** — methodological-pitfall checks in [`eval-harness/`](../eval-harness/README.md): does a skill flag the known trap?
 - **Benchmark tasks** — numeric recovery checks in [`benchmark/`](../benchmark/README.md): does a pipeline get the right number?
 
-A family is **covered** when it has both an eval scenario and a benchmark task, **partial** when it has one, and a **gap** when skills claim the method but no rigor check targets it. Gaps are listed explicitly below — they are the to-do list, not an omission.
+A family is **covered** when it has both an eval scenario and a benchmark task, **partial** when it has one, **indirect** when a sibling family's checks defend it (see notes), and a **gap** when skills claim the method but no rigor check targets it. Gaps are listed explicitly below — they are the to-do list, not an omission.
 
 ## Coverage by method family
 
@@ -17,33 +17,32 @@ A family is **covered** when it has both an eval scenario and a benchmark task, 
 |---|---:|---|---|---|
 | Instrumental variables (IV / 2SLS) | 28 | `statspai-weak-iv` (critical) | `card-iv-recovery` | covered |
 | Regression discontinuity (RDD) | 26 | `statspai-rdd-diagnostics` (high) | `rdd-recovery` | covered |
-| Difference-in-differences (2x2) | 10 | — | — | gap |
+| Difference-in-differences (2x2) | 10 | — | — | indirect |
 | Staggered DiD / TWFE | 17 | `aer-identification-staggered` (critical)<br>`causal-inference-twfe-trap` (high)<br>`statspai-staggered-did` (critical) | `did-staggered-recovery` | covered |
 | Event study / pre-trends | 10 | `statspai-pretrends-eventstudy` (high) | — | eval only |
-| Panel fixed effects | 19 | — | — | gap |
-| Synthetic control | 11 | — | — | gap |
+| Panel fixed effects | 19 | `pyfixest-panel-clustering` (high) | — | eval only |
+| Synthetic control | 11 | `statspai-synthetic-control` (high) | — | eval only |
 | Matching / propensity scores | 10 | `statspai-matching-overlap` (high) | `lalonde-recovery` | covered |
-| Double/debiased ML | 10 | — | — | gap |
-| Bayesian methods | 13 | — | — | gap |
-| Survival / duration | 3 | — | — | gap |
+| Double/debiased ML | 10 | `statspai-dml-crossfit` (high) | — | eval only |
+| Bayesian methods | 13 | `baygent-bayesian-diagnostics` (high) | — | eval only |
+| Survival / duration | 3 | `statspai-survival-assumptions` (high) | — | eval only |
 
 Notes:
 
-- **Difference-in-differences (2x2)** — 2x2 base case; staggered identification is tested under Staggered DiD.
-- **Panel fixed effects** — Clustered-inference check (cross-cutting) applies here.
+- **Difference-in-differences (2x2)** — 2x2 base case; the parallel-trends/pre-trends check lives under Event study, and staggered identification under Staggered DiD.
 
 ## Open gaps (skills exist, rigor check missing)
 
-- **Difference-in-differences (2x2)** — 10 skills tagged, no eval scenario or benchmark task yet.
-- **Panel fixed effects** — 19 skills tagged, no eval scenario or benchmark task yet.
-- **Synthetic control** — 11 skills tagged, no eval scenario or benchmark task yet.
-- **Double/debiased ML** — 10 skills tagged, no eval scenario or benchmark task yet.
-- **Bayesian methods** — 13 skills tagged, no eval scenario or benchmark task yet.
-- **Survival / duration** — 3 skills tagged, no eval scenario or benchmark task yet.
+- None — every method family with tagged skills has at least one rigor check.
 
 Partially covered (one of two layers):
 
 - **Event study / pre-trends** — eval only.
+- **Panel fixed effects** — eval only.
+- **Synthetic control** — eval only.
+- **Double/debiased ML** — eval only.
+- **Bayesian methods** — eval only.
+- **Survival / duration** — eval only.
 
 ## Cross-cutting checks (method-agnostic)
 
@@ -69,4 +68,4 @@ Non-method checks that gate the rest of the workflow (writing, citations, reprod
 
 ---
 
-_18 eval scenarios and 5 benchmark tasks across 11 method families; 4 families fully covered, 6 open gaps. Regenerate with `make catalog`._
+_23 eval scenarios and 5 benchmark tasks across 11 method families; 4 families fully covered, 0 open gaps. Regenerate with `make catalog`._

--- a/eval-harness/scenarios/baygent-bayesian-diagnostics.toml
+++ b/eval-harness/scenarios/baygent-bayesian-diagnostics.toml
@@ -1,0 +1,63 @@
+id = "baygent-bayesian-diagnostics"
+skill = "skills/23-Learning-Bayesian-Statistics-baygent-skills"
+title = "Bayesian estimates must report convergence diagnostics and prior sensitivity"
+category = "statistical-validity"
+severity = "high"
+context_data = []
+
+prompt = """
+I fit a Bayesian hierarchical model with MCMC and want to report the posterior
+for a treatment effect. What do I need to check and report before I trust and
+present the posterior?
+"""
+
+[[rubric]]
+id = "convergence-diagnostics"
+check = "regex_any"
+required = true
+weight = 4
+description = "Reports MCMC convergence diagnostics (R-hat, effective sample size, divergences, trace plots)."
+patterns = [
+  '(?i)\br.?hat\b',
+  '(?i)gelman.?rubin',
+  '(?i)effective sample size',
+  '(?i)\bESS\b',
+  '(?i)diverg(ent|ence)',
+  '(?i)trace plot',
+]
+
+[[rubric]]
+id = "prior-sensitivity"
+check = "regex_any"
+required = true
+weight = 3
+description = "Checks prior sensitivity / uses weakly informative priors and reports robustness to the prior."
+patterns = [
+  '(?i)prior sensitivity',
+  '(?i)prior (predictive|check)',
+  '(?i)weakly informative prior',
+  '(?i)sensitivity to (the )?prior',
+]
+
+[[rubric]]
+id = "posterior-predictive"
+check = "regex_any"
+required = false
+weight = 2
+description = "Runs posterior predictive checks to assess model fit."
+patterns = [
+  '(?i)posterior predictive',
+  '(?i)\bPPC\b',
+]
+
+[[rubric]]
+id = "credible-interval"
+check = "regex_any"
+required = false
+weight = 1
+description = "Summarizes uncertainty with credible intervals / posterior probabilities (not mislabeled as frequentist CIs)."
+patterns = [
+  '(?i)credible interval',
+  '(?i)posterior (interval|probability)',
+  '(?i)highest density interval',
+]

--- a/eval-harness/scenarios/pyfixest-panel-clustering.toml
+++ b/eval-harness/scenarios/pyfixest-panel-clustering.toml
@@ -1,0 +1,60 @@
+id = "pyfixest-panel-clustering"
+skill = "skills/40-py-econometrics-pyfixest"
+title = "Panel fixed-effects estimates must cluster standard errors and address serial correlation"
+category = "causal-identification"
+severity = "high"
+context_data = []
+
+prompt = """
+I have a state-by-year panel and want to estimate the effect of a state policy on
+an outcome with two-way (state and year) fixed effects. Run it and report the
+coefficient and its inference the way a careful applied micro paper would.
+"""
+
+[[rubric]]
+id = "clustered-se"
+check = "regex_any"
+required = true
+weight = 4
+description = "Clusters standard errors at the panel-unit (state) level rather than reporting iid/heteroskedastic-only SEs."
+patterns = [
+  '(?i)cluster(ed)?( standard errors| SEs| at| by)',
+  '(?i)cluster.{0,15}(state|unit|id|group|panel)',
+  '(?i)clustered? at the (state|unit|panel)',
+]
+
+[[rubric]]
+id = "serial-correlation-aware"
+check = "regex_any"
+required = true
+weight = 3
+description = "Flags within-unit serial correlation as the reason naive/iid standard errors understate uncertainty in panels."
+patterns = [
+  '(?i)serial correlation',
+  '(?i)autocorrelat',
+  '(?i)within.?(unit|state|panel).{0,20}correlat',
+  '(?i)(iid|conventional|default).{0,25}(understate|too small|wrong|biased)',
+]
+
+[[rubric]]
+id = "few-clusters"
+check = "regex_any"
+required = false
+weight = 2
+description = "Considers a few-clusters correction (wild cluster bootstrap) when the number of clusters is small."
+patterns = [
+  '(?i)few clusters',
+  '(?i)wild (cluster )?bootstrap',
+  '(?i)number of clusters',
+]
+
+[[rubric]]
+id = "twoway-fe"
+check = "regex_any"
+required = false
+weight = 1
+description = "Specifies two-way (unit and time) fixed effects."
+patterns = [
+  '(?i)two.?way fixed effects',
+  '(?i)(unit|state) and (time|year) fixed effects',
+]

--- a/eval-harness/scenarios/statspai-dml-crossfit.toml
+++ b/eval-harness/scenarios/statspai-dml-crossfit.toml
@@ -1,0 +1,63 @@
+id = "statspai-dml-crossfit"
+skill = "skills/00-Full-empirical-analysis-skill_StatsPAI"
+title = "Double/debiased ML must cross-fit and use orthogonal scores, not a naive ML plug-in"
+category = "causal-identification"
+severity = "high"
+context_data = []
+
+prompt = """
+I have a treatment, an outcome, and a few hundred potential controls. I want to
+use machine learning for the nuisance functions and still get a valid estimate
+and confidence interval for the treatment effect. Walk me through doing this
+correctly.
+"""
+
+[[rubric]]
+id = "cross-fitting"
+check = "regex_any"
+required = true
+weight = 4
+description = "Uses cross-fitting / sample splitting (out-of-fold nuisance predictions) to avoid own-observation overfitting bias."
+patterns = [
+  '(?i)cross.?fitting',
+  '(?i)sample splitting',
+  '(?i)out.?of.?fold',
+  '(?i)\bk.?fold\b.{0,25}nuisance',
+]
+
+[[rubric]]
+id = "orthogonal-score"
+check = "regex_any"
+required = true
+weight = 4
+description = "Uses a Neyman-orthogonal / doubly-robust moment so the estimate is first-order insensitive to nuisance error."
+patterns = [
+  '(?i)neyman.?orthogonal',
+  '(?i)orthogonal(i[sz]ed)? (score|moment)',
+  '(?i)doubly.?robust',
+  '(?i)debiased',
+]
+
+[[rubric]]
+id = "regularization-bias"
+check = "regex_any"
+required = true
+weight = 3
+description = "Explains that a naive ML plug-in carries regularization/overfitting bias that invalidates conventional inference."
+patterns = [
+  '(?i)regulari[sz]ation bias',
+  '(?i)plug.?in.{0,20}bias',
+  '(?i)naive (ml|machine learning).{0,30}(bias|invalid)',
+  '(?i)overfitting bias',
+]
+
+[[rubric]]
+id = "nuisance-not-causal"
+check = "regex_any"
+required = false
+weight = 1
+description = "Does not interpret the ML nuisance models' coefficients as causal."
+patterns = [
+  '(?i)nuisance (function|model|parameter)',
+  '(?i)not (interpret|treat).{0,25}(coefficients|nuisance).{0,15}(causal|structural)',
+]

--- a/eval-harness/scenarios/statspai-survival-assumptions.toml
+++ b/eval-harness/scenarios/statspai-survival-assumptions.toml
@@ -1,0 +1,63 @@
+id = "statspai-survival-assumptions"
+skill = "skills/00-Full-empirical-analysis-skill_StatsPAI"
+title = "Survival analysis must handle censoring and check the proportional-hazards assumption"
+category = "statistical-validity"
+severity = "high"
+context_data = []
+
+prompt = """
+I have time-to-event data — duration until an event happens — and many
+observations are still ongoing (censored) at the end of the study. I want to
+estimate how a treatment changes the risk of the event over time. How should I
+analyze this properly?
+"""
+
+[[rubric]]
+id = "handles-censoring"
+check = "regex_any"
+required = true
+weight = 4
+description = "Handles right-censoring with a survival method instead of dropping censored cases or running OLS on observed durations."
+patterns = [
+  '(?i)censor(ing|ed)',
+  '(?i)right.?censor',
+  '(?i)(do not|don.?t|avoid).{0,25}(ols|linear regression).{0,25}(duration|time.?to.?event)',
+]
+
+[[rubric]]
+id = "proportional-hazards"
+check = "regex_any"
+required = true
+weight = 4
+description = "Tests the proportional-hazards assumption (Schoenfeld residuals, log-log plot, or time-varying coefficients) when using Cox."
+patterns = [
+  '(?i)proportional hazards',
+  '(?i)schoenfeld',
+  '(?i)log.?log (plot|survival)',
+  '(?i)time.?varying (coefficient|effect|covariate)',
+]
+
+[[rubric]]
+id = "survival-estimator"
+check = "regex_any"
+required = true
+weight = 3
+description = "Uses an appropriate survival estimator (Kaplan-Meier, Cox proportional hazards, or a parametric survival model) and reports hazard ratios."
+patterns = [
+  '(?i)kaplan.?meier',
+  '(?i)\bcox\b',
+  '(?i)proportional.?hazards model',
+  '(?i)hazard ratio',
+  '(?i)parametric survival',
+]
+
+[[rubric]]
+id = "competing-risks"
+check = "regex_any"
+required = false
+weight = 1
+description = "Considers competing risks / cumulative incidence when other events preclude the event of interest."
+patterns = [
+  '(?i)competing risks',
+  '(?i)cumulative incidence',
+]

--- a/eval-harness/scenarios/statspai-synthetic-control.toml
+++ b/eval-harness/scenarios/statspai-synthetic-control.toml
@@ -1,0 +1,75 @@
+id = "statspai-synthetic-control"
+skill = "skills/00-Full-empirical-analysis-skill_StatsPAI"
+title = "Synthetic control must show pre-treatment fit, placebo inference, and a credible donor pool"
+category = "causal-identification"
+severity = "high"
+context_data = []
+
+prompt = """
+I want to estimate the effect of a state-level policy that took effect in one
+state in 1989 (think a Proposition-99-style tobacco tax) on per-capita cigarette
+sales, using other states as a comparison. Build a synthetic control and report
+the effect the way a careful applied paper would.
+"""
+
+[[rubric]]
+id = "pre-treatment-fit"
+check = "regex_any"
+required = true
+weight = 4
+description = "Reports pre-treatment fit (pre-period RMSPE / how well the synthetic matches before the intervention)."
+patterns = [
+  '(?i)pre.?(treatment|period|intervention).{0,15}(fit|match|rmspe)',
+  '(?i)\bRMSPE\b',
+  '(?i)pre.?treatment fit',
+  '(?i)fit (in|over|during) the pre',
+]
+
+[[rubric]]
+id = "placebo-inference"
+check = "regex_any"
+required = true
+weight = 4
+description = "Uses placebo / permutation inference (in-space or in-time placebos, post/pre RMSPE ratio) rather than conventional standard errors."
+patterns = [
+  '(?i)placebo',
+  '(?i)permutation (test|inference)',
+  '(?i)in.?(space|time) placebo',
+  '(?i)post.{0,5}pre RMSPE',
+]
+
+[[rubric]]
+id = "donor-pool"
+check = "regex_any"
+required = true
+weight = 3
+description = "Justifies the donor pool and the convex-combination weights (no extrapolation outside the support of the donors)."
+patterns = [
+  '(?i)donor pool',
+  '(?i)comparison (units|states|donors)',
+  '(?i)convex (hull|combination)',
+  '(?i)weights sum to (one|1)',
+]
+
+[[rubric]]
+id = "no-anticipation"
+check = "regex_any"
+required = false
+weight = 1
+description = "Considers anticipation effects around the intervention date."
+patterns = [
+  '(?i)anticipation',
+  '(?i)pre.?intervention (shock|trend break)',
+]
+
+[[rubric]]
+id = "small-sample-inference"
+check = "regex_any"
+required = false
+weight = 1
+description = "Notes that conventional large-sample inference is not appropriate (few pre-periods / few controls; consider conformal SC)."
+patterns = [
+  '(?i)small number of (pre.?period|controls|donors)',
+  '(?i)conformal',
+  '(?i)cannot rely on (large.?sample|asymptotic)',
+]

--- a/scripts/build-coverage-map.py
+++ b/scripts/build-coverage-map.py
@@ -69,6 +69,11 @@ SCENARIO_METHOD = {
     "aer-identification-staggered": "staggered-did",
     "statspai-pretrends-eventstudy": "event-study",
     "statspai-matching-overlap": "matching",
+    "statspai-synthetic-control": "synthetic-control",
+    "pyfixest-panel-clustering": "panel-fe",
+    "statspai-dml-crossfit": "dml",
+    "baygent-bayesian-diagnostics": "bayesian",
+    "statspai-survival-assumptions": "survival",
     "statspai-bad-controls": "*",
     "statspai-clustered-inference": "*",
     "aer-robustness-multiple-testing": "*",
@@ -93,8 +98,7 @@ TASK_METHOD = {
 
 # Short notes where a family is defended indirectly by a sibling family.
 RELATED_NOTE = {
-    "did": "2x2 base case; staggered identification is tested under Staggered DiD.",
-    "panel-fe": "Clustered-inference check (cross-cutting) applies here.",
+    "did": "2x2 base case; the parallel-trends/pre-trends check lives under Event study, and staggered identification under Staggered DiD.",
 }
 
 
@@ -181,6 +185,8 @@ def render() -> str:
             return "eval only"
         if has_b:
             return "benchmark only"
+        if method in RELATED_NOTE:
+            return "indirect"
         return "gap"
 
     lines: list[str] = []
@@ -209,9 +215,9 @@ def render() -> str:
     lines.append("")
     lines.append(
         "A family is **covered** when it has both an eval scenario and a benchmark task, "
-        "**partial** when it has one, and a **gap** when skills claim the method but no "
-        "rigor check targets it. Gaps are listed explicitly below — they are the to-do list, "
-        "not an omission."
+        "**partial** when it has one, **indirect** when a sibling family's checks defend it "
+        "(see notes), and a **gap** when skills claim the method but no rigor check targets "
+        "it. Gaps are listed explicitly below — they are the to-do list, not an omission."
     )
     lines.append("")
 


### PR DESCRIPTION
## What & why

PR #34 was squash-merged at an earlier commit, so the **5 method-specific eval scenarios** that close the remaining rigor-coverage gaps did not make it into `main` (only `statspai-matching-overlap` did). This PR re-lands them cleanly on top of current `main`.

Each previously-uncovered method family (skills tagged, no rigor check) gets one eval scenario gating its classic pitfalls:

- **synthetic control** (`statspai-synthetic-control`): pre-treatment fit/RMSPE, placebo/permutation inference, credible donor pool + convex weights.
- **panel fixed effects** (`pyfixest-panel-clustering`): cluster SEs at the unit, serial-correlation awareness, few-clusters wild bootstrap.
- **double/debiased ML** (`statspai-dml-crossfit`): cross-fitting, Neyman-orthogonal score, regularization-bias warning.
- **Bayesian** (`baygent-bayesian-diagnostics`): R-hat/ESS/divergences, prior sensitivity, posterior predictive checks.
- **survival** (`statspai-survival-assumptions`): censoring handling, proportional-hazards test, appropriate estimator.

`scripts/build-coverage-map.py` is updated to classify the 5 scenarios and to add an **`indirect`** status (so 2×2 DiD, defended by the event-study + staggered siblings, is not mislabeled a gap). `docs/RIGOR_COVERAGE.md` is regenerated: **open gaps now 0** — every method family with tagged skills has at least one rigor check.

## Scope note

This PR is **eval scenarios only**. Numeric `benchmark/` tasks for the 6 eval-only families are being built separately (a parallel effort owns `benchmark/check_benchmark.py` etc.); this change deliberately does not touch `benchmark/` to avoid collision.

No candidate fixtures added, so eval-smoke stays at 8 graded; 23 scenarios and auto-checks stay above the 17/80 floors (no Makefile count changes).

## Verification

Full `make check` green: `make validate` (0 errors, coverage map current), 180 unit tests, eval-harness (23 scenarios valid), eval-smoke (8/23, 1 designed required-failure), benchmark-lint (5 tasks), benchmark (all N/N, no required failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)