### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #52)

### DIFF
--- a/skills/13-scunning1975-MixtapeTools/skills/compiledeck/SKILL.md
+++ b/skills/13-scunning1975-MixtapeTools/skills/compiledeck/SKILL.md
@@ -2,7 +2,7 @@
 name: compiledeck
 description: Create and compile beautiful Beamer presentations following the Rhetoric of Decks philosophy. Use when making slides, creating decks, or compiling .tex presentation files.
 allowed-tools: Bash(pdflatex*), Bash(latexmk*), Bash(ls*), Bash(open*), Bash(python*), Read, Write, Edit, Glob, Grep
-argument-hint: [topic-or-tex-file-path]
+argument-hint: "[topic-or-tex-file-path]"
 ---
 
 # Compile Deck

--- a/skills/13-scunning1975-MixtapeTools/skills/newproject/SKILL.md
+++ b/skills/13-scunning1975-MixtapeTools/skills/newproject/SKILL.md
@@ -2,7 +2,7 @@
 name: newproject
 description: Scaffold a new research project with standard directory structure, CLAUDE.md template, and documented README. Use this at the start of every new project to ensure consistent organization.
 allowed-tools: Bash(mkdir*), Bash(cp*), Bash(ls*), Write, Read
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 ---
 
 # New Project Scaffold

--- a/skills/13-scunning1975-MixtapeTools/skills/split-pdf/SKILL.md
+++ b/skills/13-scunning1975-MixtapeTools/skills/split-pdf/SKILL.md
@@ -2,7 +2,7 @@
 name: split-pdf
 description: Download, split, and deeply read academic PDFs. Use when asked to read, review, or summarize an academic paper. Splits PDFs into 4-page chunks, reads them in small batches, and produces structured reading notes — avoiding context window crashes and shallow comprehension.
 allowed-tools: Bash(python*), Bash(pip*), Bash(curl*), Bash(wget*), Bash(mkdir*), Bash(ls*), Read, Write, Edit, WebSearch, WebFetch
-argument-hint: [pdf-path-or-search-query]
+argument-hint: "[pdf-path-or-search-query]"
 ---
 
 # Split-PDF: Download, Split, and Deep-Read Academic Papers

--- a/skills/21-claesbackman-AI-research-feedback/Skills/review-paper-code.md
+++ b/skills/21-claesbackman-AI-research-feedback/Skills/review-paper-code.md
@@ -2,7 +2,7 @@
 name: review-paper-code
 description: Review research code for reproducibility and quality, extract the paper's main empirical claims, compare paper to code, and write a constructive markdown report. Designed for social science / economics projects with LaTeX papers and Stata, R, or Python code.
 user-invocable: true
-argument-hint: [optional: path/to/main.tex] [optional: path/to/code_dir] [optional: main|full]
+argument-hint: "[optional: path/to/main.tex] [optional: path/to/code_dir] [optional: main|full]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/README.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/SKILL.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -656,7 +656,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -685,7 +685,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -722,7 +722,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -758,7 +758,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -775,7 +775,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/plugin-commands.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/simple-commands.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/advanced-workflows.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/documentation-patterns.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/frontmatter-reference.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/interactive-commands.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/plugin-features-reference.md
+++ b/skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/skills/34-andrehuang-research-companion/skills/research-companion/SKILL.md
+++ b/skills/34-andrehuang-research-companion/skills/research-companion/SKILL.md
@@ -3,7 +3,7 @@ name: research-companion
 description: >-
   Strategic research companion — brainstorm, evaluate, and decide on research directions. TRIGGER when the user wants to brainstorm research, evaluate research ideas, do project triage, or explore a problem space. Orchestrates brainstormer, idea-critic, and research-strategist agents through a 6-phase pipeline: Seed → Diverge → Evaluate → Deepen → Frame → Decide. Includes Carlini's conclusion-first test.
 allowed-tools: Agent, Read, Glob, Grep, WebSearch, WebFetch
-argument-hint: [topic or problem space description]
+argument-hint: "[topic or problem space description]"
 ---
 
 # Research Companion — Structured Ideation Session

--- a/skills/42-wanshuiyin-ARIS/skills/ablation-planner/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/ablation-planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ablation-planner
 description: Use when main results pass result-to-claim (claim_supported=yes or partial) and ablation studies are needed for paper submission. Codex designs ablations from a reviewer's perspective, CC reviews feasibility and implements.
-argument-hint: [method-description-or-claim]
+argument-hint: "[method-description-or-claim]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/analyze-results/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/analyze-results/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-results
 description: Analyze ML experiment results, compute statistics, generate comparison tables and insights. Use when user says "analyze results", "compare", or needs to interpret experimental data.
-argument-hint: [results-path-or-description]
+argument-hint: "[results-path-or-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/arxiv/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/arxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: arxiv
 description: Search, download, and summarize academic papers from arXiv. Use when user says "search arxiv", "download paper", "fetch arxiv", "arxiv search", "get paper pdf", or wants to find and save papers from arXiv to the local paper library.
-argument-hint: [query-or-arxiv-id]
+argument-hint: "[query-or-arxiv-id]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/auto-paper-improvement-loop/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-paper-improvement-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-paper-improvement-loop
 description: "Autonomously improve a generated paper via GPT-5.4 xhigh review → implement fixes → recompile, for 2 rounds. Use when user says \"改论文\", \"improve paper\", \"论文润色循环\", \"auto improve\", or wants to iteratively polish a generated paper."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-llm/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop-llm
 description: Autonomous research review loop using any OpenAI-compatible LLM API. Configure via llm-chat MCP server or environment variables. Trigger with "auto review loop llm" or "llm review".
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-minimax/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-minimax/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop-minimax
 description: Autonomous multi-round research review loop using MiniMax API. Use when you want to use MiniMax instead of Codex MCP for external review. Trigger with "auto review loop minimax" or "minimax review".
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/auto-review-loop/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-review-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop
 description: Autonomous multi-round research review loop. Repeatedly reviews via Codex MCP, implements fixes, and re-reviews until positive assessment or max rounds reached. Use when user says "auto review loop", "review until it passes", or wants autonomous iterative improvement.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/dse-loop/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/dse-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dse-loop
 description: "Autonomous design space exploration loop for computer architecture and EDA. Runs a program, analyzes results, tunes parameters, and iterates until objective is met or timeout. Use when user says \"DSE\", \"design space exploration\", \"sweep parameters\", \"optimize\", \"find best config\", or wants iterative parameter tuning."
-argument-hint: [task-description — include program, parameters, objective, and timeout]
+argument-hint: "[task-description — include program, parameters, objective, and timeout]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/experiment-bridge/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/experiment-bridge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-bridge
 description: "Workflow 1.5: Bridge between idea discovery and auto review. Reads EXPERIMENT_PLAN.md, implements experiment code, deploys to GPU, collects initial results. Use when user says \"实现实验\", \"implement experiments\", \"bridge\", \"从计划到跑实验\", \"deploy the plan\", or has an experiment plan ready to execute."
-argument-hint: [experiment-plan-path-or-topic]
+argument-hint: "[experiment-plan-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/feishu-notify/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/feishu-notify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: feishu-notify
 description: "Send notifications to Feishu/Lark. Internal utility used by other skills, or manually via /feishu-notify. Supports push-only (webhook) and interactive (bidirectional) modes. Use when user says \"发飞书\", \"notify feishu\", or other skills need to send status updates."
-argument-hint: [message-text]
+argument-hint: "[message-text]"
 allowed-tools: Bash(curl *), Bash(cat *), Read, Glob
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/formula-derivation/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/formula-derivation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: formula-derivation
 description: Structures and derives research formulas when the user wants to 推导公式, build a theory line, organize assumptions, turn scattered equations into a coherent derivation, or rewrite theory notes into a paper-ready formula document. Use when the derivation target is not yet fully fixed, the main object still needs to be chosen, or the user needs a coherent derivation package rather than a finished theorem proof.
-argument-hint: [problem-goal-current-formulas-or-notes]
+argument-hint: "[problem-goal-current-formulas-or-notes]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/grant-proposal/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/grant-proposal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grant-proposal
 description: "Draft a structured grant proposal from research ideas and literature. Supports KAKENHI (Japan), NSF (US), NSFC (China, including 面上/青年/优青/杰青/海外优青/重点), ERC (EU), DFG (Germany), SNSF (Switzerland), ARC (Australia), NWO (Netherlands), and generic formats. Use when user says \"write grant\", \"grant proposal\", \"申請書\", \"write KAKENHI\", \"科研費\", \"基金申请\", \"写基金\", \"NSF proposal\", or wants to turn research ideas into a funding application."
-argument-hint: [research-direction — grant-type]
+argument-hint: "[research-direction — grant-type]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/idea-creator/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/idea-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-creator
 description: Generate and rank research ideas given a broad direction. Use when user says "找idea", "brainstorm ideas", "generate research ideas", "what can we work on", or wants to explore a research area for publishable directions.
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Grep, Glob, WebSearch, WebFetch, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/idea-discovery-robot/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/idea-discovery-robot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-discovery-robot
 description: "Workflow 1 adaptation for robotics and embodied AI. Orchestrates robotics-aware literature survey, idea generation, novelty check, and critical review to go from a broad robotics direction to benchmark-grounded, simulation-first ideas. Use when user says \"robotics idea discovery\", \"机器人找idea\", \"embodied AI idea\", \"机器人方向探索\", \"sim2real 选题\", or wants ideas for manipulation, locomotion, navigation, drones, humanoids, or general robot learning."
-argument-hint: [robotics-direction]
+argument-hint: "[robotics-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/idea-discovery/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/idea-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-discovery
 description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit → idea-creator → novelty-check → research-review to go from a broad research direction to validated, pilot-tested ideas. Use when user says \"找idea全流程\", \"idea discovery pipeline\", \"从零开始找方向\", or wants the complete idea exploration workflow."
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/mermaid-diagram/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/mermaid-diagram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mermaid-diagram
 description: Generate Mermaid diagrams from user requirements. Saves .mmd and .md files to figures/ directory with syntax verification. Supports flowcharts, sequence diagrams, class diagrams, ER diagrams, Gantt charts, and 18 more diagram types.
-argument-hint: [diagram description or requirements]
+argument-hint: "[diagram description or requirements]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/monitor-experiment/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/monitor-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monitor-experiment
 description: Monitor running experiments, check progress, collect results. Use when user says "check results", "is it done", "monitor", or wants experiment output.
-argument-hint: [server-alias or screen-name]
+argument-hint: "[server-alias or screen-name]"
 allowed-tools: Bash(ssh *), Bash(echo *), Read, Write, Edit
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/novelty-check/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: novelty-check
 description: Verify research idea novelty against recent literature. Use when user says "查新", "novelty check", "有没有人做过", "check novelty", or wants to verify a research idea is novel before implementing.
-argument-hint: [method-or-idea-description]
+argument-hint: "[method-or-idea-description]"
 allowed-tools: WebSearch, WebFetch, Grep, Read, Glob, mcp__codex__codex
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-compile/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-compile
 description: "Compile LaTeX paper to PDF, fix errors, and verify output. Use when user says \"编译论文\", \"compile paper\", \"build PDF\", \"生成PDF\", or wants to compile LaTeX into a submission-ready PDF."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-figure/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-figure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-figure
 description: "Generate publication-quality figures and tables from experiment results. Use when user says \"画图\", \"作图\", \"generate figures\", \"paper figures\", or needs plots for a paper."
-argument-hint: [figure-plan-or-data-path]
+argument-hint: "[figure-plan-or-data-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-illustration/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-illustration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-illustration
 description: "Generate publication-quality AI illustrations for academic papers using Gemini image generation. Creates architecture diagrams, method illustrations with Claude-supervised iterative refinement loop. Use when user says \"生成图表\", \"画架构图\", \"AI绘图\", \"paper illustration\", \"generate diagram\", or needs visual figures for papers."
-argument-hint: [description-or-method-file]
+argument-hint: "[description-or-method-file]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply, WebSearch
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-plan/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-plan
 description: "Generate a structured paper outline from review conclusions and experiment results. Use when user says \"写大纲\", \"paper outline\", \"plan the paper\", \"论文规划\", or wants to create a paper plan before writing."
-argument-hint: [topic-or-narrative-doc]
+argument-hint: "[topic-or-narrative-doc]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-poster/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster
 description: "Generate a conference poster (article + tcbposter LaTeX → A0/A1 PDF + editable PPTX + SVG) from a compiled paper. Use when user says \"做海报\", \"制作海报\", \"conference poster\", \"make poster\", \"生成poster\", \"poster session\", or wants to create a poster for a conference presentation."
-argument-hint: [paper-directory-or-venue]
+argument-hint: "[paper-directory-or-venue]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-slides/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-write/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-write
 description: "Draft LaTeX paper section by section from an outline. Use when user says \"写论文\", \"write paper\", \"draft LaTeX\", \"开始写\", or wants to generate LaTeX content from a paper plan."
-argument-hint: [venue-or-section]
+argument-hint: "[venue-or-section]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/paper-writing/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/paper-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-writing
 description: "Workflow 3: Full paper writing pipeline. Orchestrates paper-plan → paper-figure → paper-write → paper-compile → auto-paper-improvement-loop to go from a narrative report to a polished, submission-ready PDF. Use when user says \"写论文全流程\", \"write paper pipeline\", \"从报告到PDF\", \"paper writing\", or wants the complete paper generation workflow."
-argument-hint: [narrative-report-path-or-topic]
+argument-hint: "[narrative-report-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/pixel-art/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/pixel-art/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pixel-art
 description: Generate pixel art SVG illustrations for READMEs, docs, or slides. Use when user says "画像素图", "pixel art", "make an SVG illustration", "README hero image", or wants a cute visual.
-argument-hint: [description of what to draw]
+argument-hint: "[description of what to draw]"
 allowed-tools: Write, Edit, Read, Bash(open *)
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/proof-writer/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/proof-writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: proof-writer
 description: Writes rigorous mathematical proofs for ML/AI theory. Use when asked to prove a theorem, lemma, proposition, or corollary, fill in missing proof steps, formalize a proof sketch, 补全证明, 写证明, 证明某个命题, or determine whether a claimed proof can actually be completed under the stated assumptions.
-argument-hint: [theorem-statement-and-assumptions]
+argument-hint: "[theorem-statement-and-assumptions]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/rebuttal/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/rebuttal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rebuttal
 description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds. Use when user says \"rebuttal\", \"reply to reviewers\", \"ICML rebuttal\", \"OpenReview response\", or wants to answer external reviews safely."
-argument-hint: [paper-path-or-review-bundle]
+argument-hint: "[paper-path-or-review-bundle]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/research-lit/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/research-lit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-lit
 description: Search and analyze research papers, find related work, summarize key ideas. Use when user says "find papers", "related work", "literature review", "what does this paper say", or needs to understand academic papers.
-argument-hint: [paper-topic-or-url]
+argument-hint: "[paper-topic-or-url]"
 allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent, mcp__zotero__*, mcp__obsidian-vault__*
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/research-pipeline/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/research-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-pipeline
 description: "Full research pipeline: Workflow 1 (idea discovery) → implementation → Workflow 2 (auto review loop). Goes from a broad research direction all the way to a submission-ready paper. Use when user says \"全流程\", \"full pipeline\", \"从找idea到投稿\", \"end-to-end research\", or wants the complete autonomous research lifecycle."
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/research-review/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/research-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-review
 description: Get a deep critical review of research from GPT via Codex MCP. Use when user says "review my research", "help me review", "get external review", or wants critical feedback on research ideas, papers, or experimental results.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/result-to-claim/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/result-to-claim/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: result-to-claim
 description: Use when experiments complete to judge what claims the results support, what they don't, and what evidence is still missing. Codex MCP evaluates results against intended claims and routes to next action (pivot, supplement, or confirm). Use after experiments finish — before writing the paper or running ablations.
-argument-hint: [experiment-description-or-wandb-run]
+argument-hint: "[experiment-description-or-wandb-run]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/run-experiment/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/run-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-experiment
 description: Deploy and run ML experiments on local or remote GPU servers. Use when user says "run experiment", "deploy to server", "跑实验", or needs to launch training jobs.
-argument-hint: [experiment-description]
+argument-hint: "[experiment-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-poster/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster
 description: "Generate a conference poster (article + tcbposter LaTeX → A0/A1 PDF + editable PPTX + SVG) from a compiled paper. Use when user says \"做海报\", \"制作海报\", \"conference poster\", \"make poster\", \"生成poster\", \"poster session\", or wants to create a poster for a conference presentation."
-argument-hint: [paper-directory-or-venue]
+argument-hint: "[paper-directory-or-venue]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__gemini-review__review, mcp__gemini-review__review_start, mcp__gemini-review__review_reply_start, mcp__gemini-review__review_status
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-slides/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__gemini-review__review, mcp__gemini-review__review_start, mcp__gemini-review__review_reply_start, mcp__gemini-review__review_status
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-poster/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster
 description: "Generate a conference poster (article + tcbposter LaTeX → A0/A1 PDF + editable PPTX + SVG) from a compiled paper. Use when user says \"做海报\", \"制作海报\", \"conference poster\", \"make poster\", \"生成poster\", \"poster session\", or wants to create a poster for a conference presentation."
-argument-hint: [paper-directory-or-venue]
+argument-hint: "[paper-directory-or-venue]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-slides/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/training-check/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/training-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: training-check
 description: Periodically check WandB metrics during training to catch problems early (NaN, loss divergence, idle GPUs). Avoids wasting GPU hours on broken runs. Use when training is running and you want automated health checks.
-argument-hint: [wandb-run-path]
+argument-hint: "[wandb-run-path]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/42-wanshuiyin-ARIS/skills/vast-gpu/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/vast-gpu/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vast-gpu
 description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
-argument-hint: [task-description or action]
+argument-hint: "[task-description or action]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 ---
 

--- a/skills/67-econfin-workflow-toolkit/command-development/README.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/67-econfin-workflow-toolkit/command-development/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Check environment argument: $1
@@ -776,7 +776,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/67-econfin-workflow-toolkit/command-development/examples/plugin-commands.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/67-econfin-workflow-toolkit/command-development/examples/simple-commands.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/67-econfin-workflow-toolkit/command-development/references/advanced-workflows.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/67-econfin-workflow-toolkit/command-development/references/documentation-patterns.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/67-econfin-workflow-toolkit/command-development/references/frontmatter-reference.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/67-econfin-workflow-toolkit/command-development/references/interactive-commands.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/67-econfin-workflow-toolkit/command-development/references/plugin-features-reference.md
+++ b/skills/67-econfin-workflow-toolkit/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: $1 must be one of: dev, staging, prod
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/skills/67-econfin-workflow-toolkit/master-thesis-review/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/master-thesis-review/SKILL.md
@@ -2,7 +2,7 @@
 name: master-thesis-review
 description: Generate master's thesis review reports (硕士论文评阅意见) calibrated to a given score. Outputs academic evaluation and shortcomings/suggestions in Chinese. Trigger when user says "master thesis review" / "硕士论文评阅" / "论文评阅" / "评阅意见" / "thesis review".
 allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash
-argument-hint: [path-to-thesis-folder]
+argument-hint: "[path-to-thesis-folder]"
 ---
 
 # Master Thesis Review (硕士论文评阅意见)

--- a/skills/67-econfin-workflow-toolkit/novelty-check/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: novelty-check
 description: Verify research idea novelty against recent literature. Use when user says "查新", "novelty check", "有没有人做过", "check novelty", or wants to verify a research idea is novel before implementing.
-argument-hint: [method-or-idea-description]
+argument-hint: "[method-or-idea-description]"
 allowed-tools: WebSearch, WebFetch, Grep, Read, Glob, mcp__codex__codex
 ---
 

--- a/skills/67-econfin-workflow-toolkit/paper-pipeline/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-pipeline/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-pipeline
 description: "Orchestrate the complete post-first-draft polishing pipeline for an academic LaTeX paper by invoking five existing skills in fixed order: (1) paper-polish, (2) paper-self-revise, (3) paper-style, (4) paper-polish again, (5) reference-verify. Trigger when user says \"paper pipeline\" / \"paper-pipeline\" / \"论文流水线\" / \"全流程打磨\" / \"一条龙打磨\" / \"初稿打磨\" / \"full polish pipeline\" / \"run the whole pipeline\", or wants the entire post-draft polishing sequence run on a paper folder. Use this skill whenever the user asks for several paper-finishing steps (polish + revise + style + reference check) on one manuscript in one go, even if they don't name every individual skill."
 allowed-tools: Skill, Read, Edit, Write, Glob, Grep, Bash, AskUserQuestion, WebSearch, WebFetch, Agent
-argument-hint: [path-to-project-folder] [target-journal(optional)]
+argument-hint: "[path-to-project-folder] [target-journal(optional)]"
 ---
 
 # Paper Pipeline

--- a/skills/67-econfin-workflow-toolkit/paper-polish/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-polish/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-polish
 description: Proofread and verify academic papers in LaTeX. Runs 19 sequential checks covering titles, consistency, citations, formatting, theoretical tension in motivation, concise results reporting, cross-section repetition, em-dash usage, and auxiliary-text-to-footnote conversion. Trigger when user says "check paper" / "proofread" / "paper-checker" / "校对" / "核查论文".
 allowed-tools: Read, Bash, Edit, Write, Glob, Grep, AskUserQuestion, WebSearch, WebFetch
-argument-hint: [path-to-paper-directory]
+argument-hint: "[path-to-paper-directory]"
 ---
 
 # Paper Checker

--- a/skills/67-econfin-workflow-toolkit/paper-referee-revise/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-referee-revise/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-referee-revise
 description: Revise an academic paper based on journal referee reports. Reads referee comments from review report or annotated manuscript, then directly modifies main.tex one comment at a time with user approval. Generates response letter after revision. Trigger when user says "referee revise" / "paper-referee-revise" / "审稿意见修改" / "根据审稿人意见修改" / "referee report".
 allowed-tools: Read, Edit, Write, Glob, Grep, AskUserQuestion, Bash
-argument-hint: [path-to-project-folder]
+argument-hint: "[path-to-project-folder]"
 ---
 
 # Paper Referee Revise

--- a/skills/67-econfin-workflow-toolkit/paper-self-revise/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-self-revise/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-self-revise
 description: Revise an academic paper based on internal review comments. Reads review report or annotated manuscript, then applies revisions one by one with user approval. Trigger when user says "self revise" / "paper-selfrevise" / "内部修改" / "根据审稿意见修改".
 allowed-tools: Read, Edit, Write, Glob, Grep, AskUserQuestion, Bash
-argument-hint: [path-to-project-folder]
+argument-hint: "[path-to-project-folder]"
 ---
 
 # Paper Self-Revise

--- a/skills/67-econfin-workflow-toolkit/paper-style/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-style/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-style
 description: Restructure an academic paper's title and section structure to match a target journal's house style. Asks the user to specify the target journal first, then adjusts main.tex accordingly (title wording and case, section skeleton, heading case, numbering scheme, merging/splitting sections). Trigger when user says "paper style" / "paper-style" / "期刊风格" / "按目标期刊调整" / "调整为XX风格" / "JFE风格" / "convert to journal style" / "restructure for [journal]", or wants a paper's title/sections reformatted for a specific journal submission.
 allowed-tools: Read, Edit, Write, Glob, Grep, AskUserQuestion, Bash, WebSearch, WebFetch
-argument-hint: [path-to-project-folder] [target-journal(optional)]
+argument-hint: "[path-to-project-folder] [target-journal(optional)]"
 ---
 
 # Paper Style

--- a/skills/67-econfin-workflow-toolkit/paper-submission/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-submission/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-submission
 description: Evaluate a paper's contribution novelty, identify best-fit SSCI journal fields and ABS star rating, and recommend 20 target journals. Trigger when user says "paper submission" / "paper-submission" / "投稿评估" / "期刊推荐" / "target journal" / "选刊".
 allowed-tools: Read, Bash, Edit, Write, Glob, Grep, AskUserQuestion, WebSearch, WebFetch, Agent
-argument-hint: [path-to-paper-pdf-or-project-folder]
+argument-hint: "[path-to-paper-pdf-or-project-folder]"
 ---
 
 # Paper Submission Evaluator

--- a/skills/67-econfin-workflow-toolkit/paper-writer/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/paper-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-writer
 description: Automatically write empirical sections of academic papers in LaTeX by reading tables/figures from a PDF. Trigger when user wants to write a paper from empirical results, has tables/figures in PDF, or says "write paper" / "paper-writer" / "写论文".
 allowed-tools: Read, Bash, Edit, Write, Glob, Grep, AskUserQuestion, WebSearch, WebFetch
-argument-hint: [path-to-pdf]
+argument-hint: "[path-to-pdf]"
 ---
 
 # Paper Writer

--- a/skills/67-econfin-workflow-toolkit/readability/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/readability/SKILL.md
@@ -2,7 +2,7 @@
 name: readability
 description: Correct grammar errors, typos, and improve academic readability in LaTeX, Markdown, or plain-text manuscripts. Scans the document once, then walks through every issue one-by-one asking for approval before applying each fix. Trigger when the user says "readability", "check grammar", "fix typos", "proofread for grammar", "improve readability", "polish wording", "语言润色", "修语法", or asks you to clean up the prose in a paper/chapter/section without wanting full content restructuring.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, AskUserQuestion
-argument-hint: [path-to-file-or-directory]
+argument-hint: "[path-to-file-or-directory]"
 ---
 
 # Readability

--- a/skills/67-econfin-workflow-toolkit/referee-report/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/referee-report/SKILL.md
@@ -2,7 +2,7 @@
 name: referee-report
 description: Generate academic referee reports for economics/finance papers, followed by a 150-word letter to the editor with recommendation (Reject / Major Revision) and Kai Wu signature. Two modes (normal / high-level), configurable number of comments; recommendation choice drives evaluation tone (Reject → negative, Major Revision → neutral). Trigger when user says "referee report" / "write referee report" / "审稿报告" / "写审稿意见" / "generate referee report" / "review this paper".
 allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash
-argument-hint: [path-to-project-folder]
+argument-hint: "[path-to-project-folder]"
 ---
 
 # Referee Report Generator

--- a/skills/67-econfin-workflow-toolkit/reference-verify/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/reference-verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reference-verify
 description: "Verify references in an academic paper: check whether each BibTeX entry is real, whether in-text citations match the cited paper's actual content, and produce a structured verification report. Use when user says \"验证参考文献\", \"ref verify\", \"check references\", \"核实引用\", \"引用是否正确\", or wants to audit citations in a LaTeX manuscript."
-argument-hint: [paper-directory-or-tex-file]
+argument-hint: "[paper-directory-or-tex-file]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch
 ---
 

--- a/skills/68-research-productivity-skills/command-development/README.md
+++ b/skills/68-research-productivity-skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/68-research-productivity-skills/command-development/SKILL.md
+++ b/skills/68-research-productivity-skills/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Check environment argument: $1
@@ -776,7 +776,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/68-research-productivity-skills/command-development/examples/plugin-commands.md
+++ b/skills/68-research-productivity-skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/68-research-productivity-skills/command-development/examples/simple-commands.md
+++ b/skills/68-research-productivity-skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/68-research-productivity-skills/command-development/references/advanced-workflows.md
+++ b/skills/68-research-productivity-skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/68-research-productivity-skills/command-development/references/documentation-patterns.md
+++ b/skills/68-research-productivity-skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/68-research-productivity-skills/command-development/references/frontmatter-reference.md
+++ b/skills/68-research-productivity-skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/68-research-productivity-skills/command-development/references/interactive-commands.md
+++ b/skills/68-research-productivity-skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/68-research-productivity-skills/command-development/references/plugin-features-reference.md
+++ b/skills/68-research-productivity-skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: $1 must be one of: dev, staging, prod
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`


### PR DESCRIPTION
Closes #52.

## Summary

Purely mechanical single-character transform to 84 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (84)

- `skills/42-wanshuiyin-ARIS/skills/analyze-results/SKILL.md`
- `skills/67-econfin-workflow-toolkit/command-development/SKILL.md`
- `skills/68-research-productivity-skills/command-development/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/novelty-check/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/SKILL.md`
- `skills/67-econfin-workflow-toolkit/command-development/README.md`
- `skills/68-research-productivity-skills/command-development/README.md`
- `skills/67-econfin-workflow-toolkit/command-development/examples/simple-commands.md`
- `skills/67-econfin-workflow-toolkit/command-development/examples/plugin-commands.md`
- `skills/42-wanshuiyin-ARIS/skills/arxiv/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/pixel-art/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/README.md`
- `skills/13-scunning1975-MixtapeTools/skills/newproject/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/monitor-experiment/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/research-review/SKILL.md`
- `skills/68-research-productivity-skills/command-development/examples/plugin-commands.md`
- `skills/68-research-productivity-skills/command-development/examples/simple-commands.md`
- `skills/42-wanshuiyin-ARIS/skills/result-to-claim/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/training-check/SKILL.md`
- `skills/67-econfin-workflow-toolkit/command-development/references/frontmatter-reference.md`
- `skills/42-wanshuiyin-ARIS/skills/ablation-planner/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/feishu-notify/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/plugin-commands.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/examples/simple-commands.md`
- `skills/67-econfin-workflow-toolkit/command-development/references/advanced-workflows.md`
- `skills/42-wanshuiyin-ARIS/skills/proof-writer/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/rebuttal/SKILL.md`
- `skills/68-research-productivity-skills/command-development/references/frontmatter-reference.md`
- `skills/67-econfin-workflow-toolkit/command-development/references/plugin-features-reference.md`
- `skills/42-wanshuiyin-ARIS/skills/dse-loop/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/vast-gpu/SKILL.md`
- `skills/68-research-productivity-skills/command-development/references/advanced-workflows.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-compile/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-plan/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-style/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/idea-creator/SKILL.md`
- `skills/67-econfin-workflow-toolkit/novelty-check/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-figure/SKILL.md`
- `skills/68-research-productivity-skills/command-development/references/plugin-features-reference.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-writing/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/run-experiment/SKILL.md`
- `skills/13-scunning1975-MixtapeTools/skills/split-pdf/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/research-lit/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/research-pipeline/SKILL.md`
- `skills/67-econfin-workflow-toolkit/readability/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/frontmatter-reference.md`
- `skills/42-wanshuiyin-ARIS/skills/auto-review-loop-llm/SKILL.md`
- `skills/67-econfin-workflow-toolkit/master-thesis-review/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-write/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/advanced-workflows.md`
- `skills/42-wanshuiyin-ARIS/skills/idea-discovery/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-pipeline/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-slides/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/formula-derivation/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/auto-review-loop/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/plugin-features-reference.md`
- `skills/67-econfin-workflow-toolkit/referee-report/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/mermaid-diagram/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/experiment-bridge/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-poster/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-polish/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/grant-proposal/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-writer/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-submission/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-self-revise/SKILL.md`
- `skills/13-scunning1975-MixtapeTools/skills/compiledeck/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/idea-discovery-robot/SKILL.md`
- `skills/67-econfin-workflow-toolkit/reference-verify/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/paper-illustration/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/auto-review-loop-minimax/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/auto-paper-improvement-loop/SKILL.md`
- `skills/67-econfin-workflow-toolkit/paper-referee-revise/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-slides/SKILL.md`
- `skills/21-claesbackman-AI-research-feedback/Skills/review-paper-code.md`
- `skills/34-andrehuang-research-companion/skills/research-companion/SKILL.md`
- `skills/42-wanshuiyin-ARIS/skills/skills-codex/paper-poster/SKILL.md`
- `skills/67-econfin-workflow-toolkit/command-development/references/documentation-patterns.md`
- `skills/68-research-productivity-skills/command-development/references/documentation-patterns.md`
- `skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-slides/SKILL.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/documentation-patterns.md`
- `skills/42-wanshuiyin-ARIS/skills/skills-codex-gemini-review/paper-poster/SKILL.md`
- `skills/67-econfin-workflow-toolkit/command-development/references/interactive-commands.md`
- `skills/68-research-productivity-skills/command-development/references/interactive-commands.md`
- `skills/33-Galaxy-Dawn-claude-scholar/skills/command-development/references/interactive-commands.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
