### PR TITLE
fix: quote remaining argument-hint in econfin-idea-finder (follow-up to #53)

### DIFF
--- a/skills/67-econfin-workflow-toolkit/econfin-idea-finder/SKILL.md
+++ b/skills/67-econfin-workflow-toolkit/econfin-idea-finder/SKILL.md
@@ -11,7 +11,7 @@ description: >
   从用户输入的研究方向派生）；< 9 分的选题在 subagent 内部直接丢弃，绝不写盘、绝不输出**。当用户说"找选题"、"帮我找选题"、"想做 X 方向"、
   "empirical CF idea search"、"批量生成研究计划书"、"100 ideas"、"econfin-idea-finder"
   时触发。
-argument-hint: [research-direction or "" for interactive]
+argument-hint: '[research-direction or "" for interactive]'
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 


### PR DESCRIPTION
## Summary

- Follow-up to #53 (issue #52): quotes the one remaining bare-bracket `argument-hint` value, in `skills/67-econfin-workflow-toolkit/econfin-idea-finder/SKILL.md`. This skill was added after #53 was opened, so that PR could not cover it.
- The value contains double quotes (`[research-direction or "" for interactive]`), so it is wrapped in single quotes instead of double quotes.
- After this change, `grep -rE '^\s*argument-hint:\s*\[' skills/` returns zero matches, and every `argument-hint` frontmatter value in the repo round-trips through `yaml.safe_load` as a `str`.

## Linked issue

- refs #52 (already closed by #53)

## Checklist

- [x] I verified the source repo, license, and install path for any new skill. (No new skill — one-line YAML quoting fix.)
- [ ] I added or updated the relevant `docs/` category entry. (Not applicable — no catalog-visible change.)
- [ ] I updated `evals/flagship-evals.json` if this changes a flagship skill or recommended workflow. (Not applicable.)
- [ ] I ran `make catalog`. (Not applicable — frontmatter value quoting only, parsed value unchanged as a string.)
- [x] I ran `make validate` — identical results before and after the change (88 pre-existing docs-link errors, none introduced by this PR).
- [x] I avoided adding skills whose core path requires a paid/proprietary API.

## Catalog impact

- [ ] Changes a skill's hygiene score
- [ ] Adds / removes a skill from `catalog/skills.json`
- [ ] Changes vendored_commit metadata for any collection.
- [ ] Affects a method-family evaluation scenario
- [ ] Affects a numeric benchmark task

None — one-character-class change to a YAML frontmatter value.

## Notes for reviewers

- Source: follow-up to community report #52 / PR #53 by @thejesh23
- License: unchanged
- Local path: `skills/67-econfin-workflow-toolkit/econfin-idea-finder/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014njzbVxHxUxSedPn9J2iC9

---
_Generated by [Claude Code](https://claude.ai/code/session_014njzbVxHxUxSedPn9J2iC9)_