### PR TITLE
Update MiniMax review model to M3

### DIFF
--- a/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-llm/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-llm/SKILL.md
@@ -47,7 +47,7 @@ Add to `~/.claude/settings.json`:
 |----------|--------------|-----------|
 | **OpenAI** | `https://api.openai.com/v1` | `gpt-4o`, `o3` |
 | **DeepSeek** | `https://api.deepseek.com/v1` | `deepseek-chat`, `deepseek-reasoner` |
-| **MiniMax** | `https://api.minimax.io/v1` | `MiniMax-M2.7` |
+| **MiniMax** | `https://api.minimax.io/v1` | `MiniMax-M3` |
 | **Kimi (Moonshot)** | `https://api.moonshot.cn/v1` | `moonshot-v1-8k`, `moonshot-v1-32k` |
 | **ZhiPu (GLM)** | `https://open.bigmodel.cn/api/paas/v4` | `glm-4`, `glm-4-plus` |
 | **SiliconFlow** | `https://api.siliconflow.cn/v1` | `Qwen/Qwen2.5-72B-Instruct` |

--- a/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-minimax/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/auto-review-loop-minimax/SKILL.md
@@ -16,7 +16,7 @@ Autonomously iterate: review → implement fixes → re-review, until the extern
 - MAX_ROUNDS = 4
 - POSITIVE_THRESHOLD: score >= 6/10, or verdict contains "accept", "sufficient", "ready for submission"
 - REVIEW_DOC: `AUTO_REVIEW.md` in project root (cumulative log)
-- REVIEWER_MODEL = `MiniMax-M2.7` — Model used via MiniMax API
+- REVIEWER_MODEL = `MiniMax-M3` — Model used via MiniMax API
 
 ## API Configuration
 
@@ -30,7 +30,7 @@ If `mcp__minimax-chat__minimax_chat` is available, use it:
 mcp__minimax-chat__minimax_chat:
   prompt: |
     [Review prompt content]
-  model: "MiniMax-M2.7"
+  model: "MiniMax-M3"
   system: "You are a senior machine learning researcher..."
 ```
 
@@ -43,7 +43,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {"role": "system", "content": "You are a senior ML researcher..."},
       {"role": "user", "content": "[Review prompt]"}
@@ -108,7 +108,7 @@ Send comprehensive context to the external reviewer.
 Use mcp__minimax-chat__minimax_chat tool with:
 - system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
 - prompt: [Full review prompt with context]
-- model: "MiniMax-M2.7"
+- model: "MiniMax-M3"
 ```
 
 **If MCP NOT available (Fallback):**
@@ -117,7 +117,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {
         "role": "system",
@@ -233,7 +233,7 @@ When loop ends (positive assessment or max rounds):
 **MCP Method (Primary):**
 ```
 mcp__minimax-chat__minimax_chat:
-  model: "MiniMax-M2.7"
+  model: "MiniMax-M3"
   system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
   prompt: |
     [Round N/MAX_ROUNDS of autonomous review loop]
@@ -269,7 +269,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {
         "role": "system",

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex/auto-review-loop-llm/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex/auto-review-loop-llm/SKILL.md
@@ -45,7 +45,7 @@ Add to `~/.codex/settings.json`:
 |----------|--------------|-----------|
 | **OpenAI** | `https://api.openai.com/v1` | `gpt-4o`, `o3` |
 | **DeepSeek** | `https://api.deepseek.com/v1` | `deepseek-chat`, `deepseek-reasoner` |
-| **MiniMax** | `https://api.minimax.io/v1` | `MiniMax-M2.7` |
+| **MiniMax** | `https://api.minimax.io/v1` | `MiniMax-M3` |
 | **Kimi (Moonshot)** | `https://api.moonshot.cn/v1` | `moonshot-v1-8k`, `moonshot-v1-32k` |
 | **ZhiPu (GLM)** | `https://open.bigmodel.cn/api/paas/v4` | `glm-4`, `glm-4-plus` |
 | **SiliconFlow** | `https://api.siliconflow.cn/v1` | `Qwen/Qwen2.5-72B-Instruct` |

--- a/skills/42-wanshuiyin-ARIS/skills/skills-codex/auto-review-loop-minimax/SKILL.md
+++ b/skills/42-wanshuiyin-ARIS/skills/skills-codex/auto-review-loop-minimax/SKILL.md
@@ -14,7 +14,7 @@ Autonomously iterate: review → implement fixes → re-review, until the extern
 - MAX_ROUNDS = 4
 - POSITIVE_THRESHOLD: score >= 6/10, or verdict contains "accept", "sufficient", "ready for submission"
 - REVIEW_DOC: `AUTO_REVIEW.md` in project root (cumulative log)
-- REVIEWER_MODEL = `MiniMax-M2.7` — Model used via MiniMax API
+- REVIEWER_MODEL = `MiniMax-M3` — Model used via MiniMax API
 
 ## API Configuration
 
@@ -28,7 +28,7 @@ If `mcp__minimax-chat__minimax_chat` is available, use it:
 mcp__minimax-chat__minimax_chat:
   message: |
     [Review prompt content]
-  model: "MiniMax-M2.7"
+  model: "MiniMax-M3"
   system: "You are a senior machine learning researcher..."
 ```
 
@@ -41,7 +41,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {"role": "system", "content": "You are a senior ML researcher..."},
       {"role": "user", "content": "[Review prompt]"}
@@ -106,7 +106,7 @@ Send comprehensive context to the external reviewer.
 Use mcp__minimax-chat__minimax_chat tool with:
 - system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
 - prompt: [Full review prompt with context]
-- model: "MiniMax-M2.7"
+- model: "MiniMax-M3"
 ```
 
 **If MCP NOT available (Fallback):**
@@ -115,7 +115,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {
         "role": "system",
@@ -230,7 +230,7 @@ When loop ends (positive assessment or max rounds):
 **MCP Method (Primary):**
 ```
 mcp__minimax-chat__minimax_chat:
-  model: "MiniMax-M2.7"
+  model: "MiniMax-M3"
   system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
   message: |
     [Round N/MAX_ROUNDS of autonomous review loop]
@@ -266,7 +266,7 @@ curl -s "https://api.minimax.io/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -d '{
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "messages": [
       {
         "role": "system",


### PR DESCRIPTION
Reason: Add the current MiniMax-M3 model to the review-loop guidance and examples.

Changes:
- Updated the supported-model tables in both generic review-loop skill variants.
- Updated the dedicated MiniMax review-loop model configuration and request examples to use MiniMax-M3 consistently.

Checks:
- `git diff --check` (passed)
- `python3 scripts/validate-repo.py` (fails on pre-existing catalog count drift and missing Paper WorkFlow submodule links)
